### PR TITLE
Fixing role slugs

### DIFF
--- a/src/pages/families.tsx
+++ b/src/pages/families.tsx
@@ -86,7 +86,9 @@ const FamiliesPageQuery = graphql`
         childrensWorkers: allSanityPerson(
             filter: {
                 roles: {
-                    elemMatch: { slug: { current: { eq: "childrens-worker" } } }
+                    elemMatch: {
+                        slug: { current: { eq: "childrens-worker" } }
+                    }
                 }
             }
         ) {


### PR DESCRIPTION
They are using hyphens as we're auto generating them in sanity and that
uses hyphens and not underscores