### PR TITLE
Convert SanityPerson bios to html at build time not runtime

### DIFF
--- a/gatsby-files/gatsby-node.ts
+++ b/gatsby-files/gatsby-node.ts
@@ -6,6 +6,9 @@
 
 import path from "path"
 import { GatsbyNode } from "gatsby"
+import { GraphQLString } from "graphql"
+// @ts-ignore
+import blocksToHtml from "@sanity/block-content-to-html"
 
 // You can delete this file if you're not using it
 export const createPages: GatsbyNode["createPages"] = async ({
@@ -78,4 +81,22 @@ export const createPages: GatsbyNode["createPages"] = async ({
             },
         })
     }
+}
+
+// @ts-ignore
+export const setFieldsOnGraphQLNodeType = ({ type }) => {
+    if (type.name === `SanityPerson`) {
+        return {
+            bioHtml: {
+                type: GraphQLString,
+                // @ts-ignore
+                resolve: source => {
+                    return blocksToHtml({ blocks: source.bio })
+                },
+            },
+        }
+    }
+
+    // by default return empty object
+    return {}
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "version": "0.1.0",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "dependencies": {
-    "@sanity/block-content-to-react": "^2.0.7",
     "@sanity/client": "^1.149.7",
     "classnames": "^2.2.6",
     "gatsby": "^2.21.7",
@@ -19,6 +18,7 @@
     "styled-components": "^5.1.0"
   },
   "devDependencies": {
+    "@sanity/block-content-to-html": "^1.3.8",
     "@types/classnames": "^2.2.10",
     "@types/jest": "^25.2.1",
     "@types/js-cookie": "^2.2.6",

--- a/src/pages/staff.tsx
+++ b/src/pages/staff.tsx
@@ -4,7 +4,6 @@ import { useStaticQuery, graphql } from "gatsby"
 import Layout from "../components/layout"
 import Img from "../components/img"
 import { sortedWithPriority } from "../utils"
-const BlockContent = require("@sanity/block-content-to-react")
 
 const StaffPageQuery = graphql`
     query StaffPage {
@@ -25,7 +24,7 @@ const StaffPageQuery = graphql`
                 name
                 jobTitle
                 email
-                _rawBio
+                bioHtml
                 headshot {
                     asset {
                         fluid(maxWidth: 400) {
@@ -63,6 +62,7 @@ const Staff = () => {
 
     const allStaff = people.map(person => {
         const email = person.email
+
         return (
             <div key={person.id} className="person">
                 <div className="photo" style={{ position: "relative" }}>
@@ -85,9 +85,10 @@ const Staff = () => {
                             <a href={`mailto:${email}`}>{email}</a>
                         </div>
                     )}
-                    <div className="bio">
-                        <BlockContent blocks={person._rawBio} />
-                    </div>
+                    <div
+                        className="bio"
+                        dangerouslySetInnerHTML={{ __html: person.bioHtml! }}
+                    />
                 </div>
             </div>
         )

--- a/yarn.lock
+++ b/yarn.lock
@@ -1894,7 +1894,14 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
-"@sanity/block-content-to-hyperscript@^2.0.10":
+"@sanity/block-content-to-html@^1.3.8":
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/@sanity/block-content-to-html/-/block-content-to-html-1.3.8.tgz#eff8e3dafe82f4a7e10ed914f7fa646c3e59ec2d"
+  integrity sha512-eXXilwPQCFe2uHMK5DItzZWg2CgaCfbo2hpcY1BbJEDPNhPjRlkaNBxM65U9M6yxreNnFffTNWHORVX3vZmIeQ==
+  dependencies:
+    "@sanity/block-content-to-hyperscript" "^2.0.5"
+
+"@sanity/block-content-to-hyperscript@^2.0.5":
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/@sanity/block-content-to-hyperscript/-/block-content-to-hyperscript-2.0.10.tgz#9cf805c5d2341d043bcab8b3740c9b3466b5ae6b"
   integrity sha512-xT3iEmZkK0fvO5PDFpn9GMWGfvOopvbrRCBU48XxpFoTxRrfsHhxbRy8J0eND1HGXHUENkIKv5jbohtGd1MiVg==
@@ -1903,14 +1910,6 @@
     "@sanity/image-url" "^0.140.15"
     hyperscript "^2.0.2"
     object-assign "^4.1.1"
-
-"@sanity/block-content-to-react@^2.0.7":
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/@sanity/block-content-to-react/-/block-content-to-react-2.0.7.tgz#6e257b5ab59ebe406005032eea586391d963eb93"
-  integrity sha512-oSriTf/3Ihnxp6AjEGiVjNPA2Iq/IFaWg4Frn5msGq5GT8N1kwLwxduig1OSn87UA15LNwiai9LAJwBR2k9lIg==
-  dependencies:
-    "@sanity/block-content-to-hyperscript" "^2.0.10"
-    prop-types "^15.6.2"
 
 "@sanity/client@^0.144.0":
   version "0.144.0"


### PR DESCRIPTION
Has two advantages:
1. Saves bytes (as we don't need to bundle the @sanity/block-content-to-react lib)
2. Saves (a tiny bit of) frontend perf