### PR TITLE
Disable native lazy loading

### DIFF
--- a/patches/gatsby-image+2.4.0.patch
+++ b/patches/gatsby-image+2.4.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/gatsby-image/index.js b/node_modules/gatsby-image/index.js
+index 7554e83..37991ba 100644
+--- a/node_modules/gatsby-image/index.js
++++ b/node_modules/gatsby-image/index.js
+@@ -149,7 +149,7 @@ var activateCacheForImage = function activateCacheForImage(props) {
+ }; // Native lazy-loading support: https://addyosmani.com/blog/lazy-loading/
+ 
+ 
+-var hasNativeLazyLoadSupport = typeof HTMLImageElement !== "undefined" && "loading" in HTMLImageElement.prototype;
++var hasNativeLazyLoadSupport = false;
+ var isBrowser = typeof window !== "undefined";
+ var hasIOSupport = isBrowser && window.IntersectionObserver;
+ var io;


### PR DESCRIPTION
Gatsby seems to do a better job at telling which images are onscreen