### PR TITLE
Allow development on giving form

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,1 @@
-GIVING_FORM_CONFIG=development
+GATSBY_GIVING_FORM_CONFIG=development

--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+GIVING_FORM_CONFIG=development

--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,1 @@
-GATSBY_GIVING_FORM_CONFIG=development
+GATSBY_GIVING_FORM_CONFIG="development"

--- a/src/components/field.tsx
+++ b/src/components/field.tsx
@@ -3,7 +3,6 @@ import React from "react"
 import styles from "./field.module.scss"
 import classNames from "classnames"
 
-
 interface Props {
     className?: string
     labelText?: string
@@ -22,7 +21,7 @@ const Field: React.FC<Props> = ({
     contextualHelp,
 }) => {
     return (
-        <div className={classNames(className,styles.main)}>
+        <div className={classNames(className, styles.main)}>
             <label className={styles.label} htmlFor={labelFor}>
                 {labelText}
             </label>

--- a/src/components/form.module.scss
+++ b/src/components/form.module.scss
@@ -1,5 +1,10 @@
 @import "../mixins/button";
 
+.developmentWarning {
+    background-color: red;
+    color: white;
+}
+
 .givingForm h1,
 .givingForm h2,
 .givingForm h3 {

--- a/src/content/givingform/main.md
+++ b/src/content/givingform/main.md
@@ -1,7 +1,6 @@
 ---
 title: Giving Form
 headerColour: dark
-googleFormId: 1FAIpQLSeED6ffZVCYFG5amGWUtTGWkr8EI-rbPO2i_f-z0Ur6XvTNTw
 ---
 Giving Form
 =============

--- a/src/pages/givingform.tsx
+++ b/src/pages/givingform.tsx
@@ -846,7 +846,7 @@ const GivingFormPage: React.FC = () => {
                 <h2>Form Configuration Error</h2>
                 <p>Sorry. There is a problem with the form configuration.</p>
                 <p>
-                    The config name is: <tt>{process.env.GATSBY_GIVING_FORM_CONFIG ?? "undefined"}</tt>
+                    The config name is: <code>{process.env.GATSBY_GIVING_FORM_CONFIG ?? "undefined"}</code>
                 </p>
                 <p>Please inform the technical contact listed at the bottom of this page.</p>
             </article>

--- a/src/pages/givingform.tsx
+++ b/src/pages/givingform.tsx
@@ -1,4 +1,4 @@
-import React, { useState, ReactElement } from "react"
+import React, { useState, ReactElement, useEffect } from "react"
 import { useStaticQuery, graphql } from "gatsby"
 import { useForm, Controller } from "react-hook-form"
 import classNames from "classnames"
@@ -208,7 +208,7 @@ function convertPayloadToGoogleFormUrl(
     return url
 }
 
-type PageState = "filling" | "submitting" | "submitted" | "error"
+type PageState = "filling" | "submitting" | "submitted" | "error" | "badconfig"
 
 const GivingFormPage: React.FC = () => {
     const [formState, setPageState] = useState<PageState>("filling")
@@ -231,6 +231,12 @@ const GivingFormPage: React.FC = () => {
             }
         }
     `)
+
+    useEffect(() => {
+        if (formConfig == null) {
+            setPageState("badconfig")
+        }
+    })
 
     const { register, handleSubmit, watch, errors, control } = useForm<
         GiftFormData
@@ -271,7 +277,7 @@ const GivingFormPage: React.FC = () => {
     const form = (
         <section>
             <article>
-                {formConfig.warning}
+                {formConfig?.warning ?? null}
                 <div className={formStyles.givingForm}>
                     <form
                         onSubmit={handleSubmit(postDataToGoogleFormApi)}
@@ -834,6 +840,19 @@ const GivingFormPage: React.FC = () => {
         </section>
     )
 
+    const badlyConfiguredForm = (
+        <section>
+            <article>
+                <h2>Form Configuration Error</h2>
+                <p>Sorry. There is a problem with the form configuration.</p>
+                <p>
+                    The config name is: <tt>{process.env.GATSBY_GIVING_FORM_CONFIG ?? "undefined"}</tt>
+                </p>
+                <p>Please inform the technical contact listed at the bottom of this page.</p>
+            </article>
+        </section>
+    )
+
     return (
         <Layout
             title="Giving Form"
@@ -848,6 +867,7 @@ const GivingFormPage: React.FC = () => {
                     }}
                 />
             </section>
+            {formState === "badconfig" ? badlyConfiguredForm : null}
             {formState === "submitted" ? submitted : form}
             {formState !== "submitted" ? (
                 <section id="notes">

--- a/src/pages/givingform.tsx
+++ b/src/pages/givingform.tsx
@@ -95,8 +95,8 @@ const config: { [configName: string]: FormConfig } = {
     },
 }
 
-const configName = process.env.GIVING_FORM_CONFIG ?? "production"
-const formConfig = config[configName]
+const configName = process.env.GATSBY_GIVING_FORM_CONFIG
+const formConfig = config[configName!] // want to die if this not set properly
 
 type GiftFormData = {
     givenName: string

--- a/src/pages/givingform.tsx
+++ b/src/pages/givingform.tsx
@@ -846,9 +846,15 @@ const GivingFormPage: React.FC = () => {
                 <h2>Form Configuration Error</h2>
                 <p>Sorry. There is a problem with the form configuration.</p>
                 <p>
-                    The config name is: <code>{process.env.GATSBY_GIVING_FORM_CONFIG ?? "undefined"}</code>
+                    The config name is:{" "}
+                    <code>
+                        {process.env.GATSBY_GIVING_FORM_CONFIG ?? "undefined"}
+                    </code>
                 </p>
-                <p>Please inform the technical contact listed at the bottom of this page.</p>
+                <p>
+                    Please inform the technical contact listed at the bottom of
+                    this page.
+                </p>
             </article>
         </section>
     )


### PR DESCRIPTION
When development environment is detected (i.e. local dev on `yarn
start`) this will use development form config and show a nice red box.

This will send form data to Tom's form. Ask me for access if you need
it.

Added typing for the config too.

Moved the google form id out of the markdown to make this a bit easier.