### PR TITLE
Hide non-existent music release links

### DIFF
--- a/src/pages/music.tsx
+++ b/src/pages/music.tsx
@@ -106,7 +106,7 @@ const MusicPage: React.FC<{}> = () => {
     // TODO: extract into component with styles
     const releases = data.releases!.frontmatter!.releases!.map(release => {
         const appleLink =
-            typeof release?.appleMusicLink !== "undefined" ? (
+            release?.appleMusicLink != null ? (
                 <a
                     className={classnames(
                         styles.musicReleaseLink,
@@ -119,7 +119,7 @@ const MusicPage: React.FC<{}> = () => {
             ) : undefined
 
         const spotifyLink =
-            typeof release?.spotifyLink !== "undefined" ? (
+            release?.spotifyLink != null ? (
                 <a
                     className={classnames(
                         styles.musicReleaseLink,


### PR DESCRIPTION
Empty `spotifyLink` and `appleMusicLink` values are actually `null` and not `undefined`. This fixes this.

This PR has the effect of removing the dead Spotify link from the The Glory and The Crown EP.
<img width="1035" alt="image" src="https://user-images.githubusercontent.com/8490192/83966760-206fd100-a8b4-11ea-890c-3397aa90e335.png">
