### PR TITLE
Stop react datepicker css appearing on each page

### DIFF
--- a/src/components/lazy-load-css.tsx
+++ b/src/components/lazy-load-css.tsx
@@ -1,0 +1,25 @@
+import React from "react"
+import { Helmet } from "react-helmet"
+
+// Technique copied from https://web.dev/defer-non-critical-css/#optimize
+
+interface Props {
+    url: string
+}
+
+const LazyLoadCss: React.FC<Props> = ({ url }) => {
+    return (
+        <Helmet>
+            <link
+                rel="preload"
+                href={url}
+                as="style"
+                // @ts-ignore
+                onload="this.onload=null;this.rel='stylesheet'" // eslint-disable-line react/no-unknown-property
+            />
+            <noscript>{`<link rel="stylesheet" href="${url}" />`}</noscript>
+        </Helmet>
+    )
+}
+
+export default LazyLoadCss

--- a/src/pages/givingform.tsx
+++ b/src/pages/givingform.tsx
@@ -5,7 +5,7 @@ import classNames from "classnames"
 import DatePicker from "react-datepicker"
 import { format } from "date-fns"
 // @ts-ignore
-import datepickerCssUrl from "!file-loader!react-datepicker/dist/react-datepicker.css"
+import datepickerCssUrl from "!file-loader!react-datepicker/dist/react-datepicker.min.css"
 import queryString from "query-string"
 
 import Layout from "../components/layout"

--- a/src/pages/givingform.tsx
+++ b/src/pages/givingform.tsx
@@ -4,7 +4,8 @@ import { useForm, Controller } from "react-hook-form"
 import classNames from "classnames"
 import DatePicker from "react-datepicker"
 import { format } from "date-fns"
-import "react-datepicker/dist/react-datepicker.css"
+// @ts-ignore
+import datepickerCssUrl from "!file-loader!react-datepicker/dist/react-datepicker.css"
 import queryString from "query-string"
 
 import Layout from "../components/layout"
@@ -13,6 +14,7 @@ import Field from "../components/field"
 import Section from "../components/section"
 import HeaderUnderlay from "../components/header-underlay"
 import SectionText from "../components/section-text"
+import LazyLoadCss from "../components/lazy-load-css"
 
 const devWarning = (
     <div className={formStyles.developmentWarning}>
@@ -279,6 +281,7 @@ const GivingFormPage: React.FC = () => {
 
     const form = (
         <Section>
+            <LazyLoadCss url={datepickerCssUrl} />
             <article>
                 {formConfig?.warning ?? null}
                 <div className={formStyles.givingForm}>


### PR DESCRIPTION
Instead load it lazily. Fixes #42 