### PR TITLE
Allow user to change cookie settings

### DIFF
--- a/src/components/cookie-notice.tsx
+++ b/src/components/cookie-notice.tsx
@@ -1,13 +1,9 @@
 import classnames from "classnames"
-import React, { useState, useEffect } from "react"
+import React from "react"
 import { graphql, useStaticQuery, Link } from "gatsby"
-import Cookies from "js-cookie"
 
 import styles from "./cookie-notice.module.scss"
-
-const COOKIE_CONSENT_KEY = "ccm_cookie_consent"
-
-type ConsentResponse = "accepted" | "declined" | undefined
+import useConsentCookie from "./hooks/useConsentCookie"
 
 const CookieNotice = () => {
     const data = useStaticQuery<GatsbyTypes.CookieNoticeQuery>(graphql`
@@ -21,32 +17,9 @@ const CookieNotice = () => {
         }
     `)
 
-    const [consentResponse, setConsentResponse] = useState<ConsentResponse>(
-        undefined
-    )
-    const [isInitialCookieLoaded, setIsInitialCookieLoaded] = useState(false)
-    useEffect(() => {
-        const cookie: ConsentResponse = Cookies.get(
-            COOKIE_CONSENT_KEY
-        ) as ConsentResponse
-        setConsentResponse(cookie)
-        setIsInitialCookieLoaded(true)
-    }, [])
+    const [consentCookie, setConsentCookie] = useConsentCookie()
 
-    useEffect(() => {
-        if (consentResponse != null) {
-            Cookies.set(COOKIE_CONSENT_KEY, consentResponse, { expires: 365 })
-        }
-        if (consentResponse === "accepted") {
-            // Enable GA
-        } else {
-            // Disable GA
-        }
-    }, [consentResponse])
-
-    // We don't want to show the notice until we've had a chance to read the
-    // cookie, otherwise we will get jank from the notice briefly flashing up.
-    const showNotice = consentResponse == null && isInitialCookieLoaded
+    const showNotice = consentCookie === "unset"
 
     return (
         <div
@@ -70,7 +43,7 @@ const CookieNotice = () => {
                 className={classnames(styles.button, styles["button--decline"])}
                 href="#"
                 onClick={() => {
-                    setConsentResponse("declined")
+                    setConsentCookie("declined")
                 }}
             >
                 Decline
@@ -80,7 +53,7 @@ const CookieNotice = () => {
                 className={classnames(styles.button, styles["button--accept"])}
                 href="#"
                 onClick={() => {
-                    setConsentResponse("accepted")
+                    setConsentCookie("accepted")
                 }}
             >
                 Accept

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -12,6 +12,7 @@ const links: Array<{ path: string; title: string }> = [
     { path: "/our-beliefs", title: "Our Beliefs" },
     { path: "/talks", title: "Talks" },
     { path: "/privacy-notice", title: "Privacy Notice" },
+    { path: "/cookies", title: "Cookies" },
     { path: "/music", title: "Music" },
     { path: "/families", title: "Families" },
     { path: "/safeguarding", title: "Safeguarding" },

--- a/src/components/hooks/useConsentCookie.ts
+++ b/src/components/hooks/useConsentCookie.ts
@@ -1,0 +1,48 @@
+import Cookies from "js-cookie"
+import { useEffect, useState } from "react"
+
+const COOKIE_CONSENT_KEY = "ccm_cookie_consent"
+const DAYS_UNTIL_EXPIRY = 365
+
+type ConsentCookieValue = "accepted" | "declined"
+type ConsentCookieReturnValue = ConsentCookieValue | "unset" | undefined
+
+/**
+ * Returns a tuple of the value of the consent cookie and a setter for the consent cookie.
+ *
+ * The returned value of the consent cookie can take one of four values - "accepted", "declined",
+ * "unset" or, while the value is being read, undefined. The consent cookie can be set to one of
+ * two values - "accepted" or "declined".
+ */
+const useConsentCookie = (): [
+    ConsentCookieReturnValue,
+    (cookie: ConsentCookieValue) => void
+] => {
+    const [consentCookieReturnValue, setConsentCookieReturnValue] = useState<
+        ConsentCookieReturnValue
+    >(undefined)
+
+    useEffect(() => {
+        const cookie: ConsentCookieValue = Cookies.get(
+            COOKIE_CONSENT_KEY
+        ) as ConsentCookieValue
+        setConsentCookieReturnValue(cookie ?? "unset")
+    }, [])
+
+    const setConsentCookie = (cookie: ConsentCookieValue) => {
+        Cookies.set(COOKIE_CONSENT_KEY, cookie, {
+            expires: DAYS_UNTIL_EXPIRY,
+        })
+        setConsentCookieReturnValue(cookie)
+
+        if (cookie === "accepted") {
+            // TODO: enable Google Analytics
+        } else {
+            // TODO: disable Google Analytics
+        }
+    }
+
+    return [consentCookieReturnValue, setConsentCookie]
+}
+
+export default useConsentCookie

--- a/src/components/switch.module.scss
+++ b/src/components/switch.module.scss
@@ -1,0 +1,70 @@
+$switch-width: 80px;
+$switch-height: var(--button-height);
+$inner-width: 50px;
+$unchecked-colour: #813030;
+$unchecked-colour-accent: #a32121;
+$checked-colour: #308130;
+$checked-colour-accent: #21a321;
+
+.switch {
+    display: inline-block;
+    position: relative;
+    width: $switch-width;
+    height: $switch-height;
+    background-color: var(--mid-gray);
+    border: 2px solid $unchecked-colour-accent;
+    border-radius: calc(#{$switch-height} / 2);
+    transition: border-color var(--menu-transition-time);
+
+    &--checked {
+        border-color: $checked-colour-accent;
+
+        .toggle {
+            background-color: $checked-colour;
+            left: calc(100% - (#{$inner-width} / 2));
+        }
+    }
+
+    &--disabled {
+        opacity: 0.2;
+    }
+}
+
+.toggle {
+    position: absolute;
+    height: $switch-height;
+    width: $inner-width;
+    background-color: $unchecked-colour;
+    border-radius: calc(#{$switch-height} / 2);
+    top: 50%;
+    left: $inner-width / 2;
+    transform: translate(-50%, -50%);
+    transition: left var(--menu-transition-time),
+        background-color var(--menu-transition-time);
+
+    > div {
+        vertical-align: middle;
+        font-size: var(--base-font-size);
+        line-height: $switch-height;
+        font-family: var(--heading-font);
+        text-transform: uppercase;
+        text-align: center;
+        color: var(--light-colour);
+        font-weight: 400;
+    }
+}
+
+.input {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: $switch-width;
+    height: $switch-height;
+    margin: 0;
+    appearance: none;
+    cursor: pointer;
+
+    &:disabled {
+        cursor: default;
+    }
+}

--- a/src/components/switch.module.scss
+++ b/src/components/switch.module.scss
@@ -1,10 +1,9 @@
 $switch-width: 80px;
 $switch-height: var(--button-height);
 $inner-width: 50px;
-$unchecked-colour: #813030;
-$unchecked-colour-accent: #a32121;
-$checked-colour: #308130;
-$checked-colour-accent: #21a321;
+$unchecked-colour: red;
+$checked-colour: #21a321;
+$switch-border-radius: 5px;
 
 .switch {
     display: inline-block;
@@ -12,12 +11,12 @@ $checked-colour-accent: #21a321;
     width: $switch-width;
     height: $switch-height;
     background-color: var(--mid-gray);
-    border: 2px solid $unchecked-colour-accent;
-    border-radius: calc(#{$switch-height} / 2);
+    border: 2px solid $unchecked-colour;
+    border-radius: $switch-border-radius;
     transition: border-color var(--menu-transition-time);
 
     &--checked {
-        border-color: $checked-colour-accent;
+        border-color: $checked-colour;
 
         .toggle {
             background-color: $checked-colour;
@@ -35,7 +34,6 @@ $checked-colour-accent: #21a321;
     height: $switch-height;
     width: $inner-width;
     background-color: $unchecked-colour;
-    border-radius: calc(#{$switch-height} / 2);
     top: 50%;
     left: $inner-width / 2;
     transform: translate(-50%, -50%);
@@ -44,10 +42,8 @@ $checked-colour-accent: #21a321;
 
     > div {
         vertical-align: middle;
-        font-size: var(--base-font-size);
+        font-size: 14pt;
         line-height: $switch-height;
-        font-family: var(--heading-font);
-        text-transform: uppercase;
         text-align: center;
         color: var(--light-colour);
         font-weight: 400;

--- a/src/components/switch.tsx
+++ b/src/components/switch.tsx
@@ -1,0 +1,39 @@
+import classnames from "classnames"
+import React from "react"
+
+import styles from "./switch.module.scss"
+
+interface SwitchProps {
+    onChange: (value: boolean) => void
+    checked: boolean
+    disabled: boolean
+    checkedText: string
+    uncheckedText: string
+}
+const Switch: React.FC<SwitchProps> = ({
+    onChange,
+    checked,
+    disabled,
+    checkedText,
+    uncheckedText,
+}) => (
+    <div
+        className={classnames(styles.switch, {
+            [styles["switch--checked"]]: checked,
+            [styles["switch--disabled"]]: disabled,
+        })}
+    >
+        <div className={styles.toggle}>
+            <div>{checked ? checkedText : uncheckedText}</div>
+        </div>
+        <input
+            type="checkbox"
+            className={styles.input}
+            checked={checked}
+            disabled={disabled}
+            onChange={({ target: { checked } }) => onChange(checked)}
+        />
+    </div>
+)
+
+export default Switch

--- a/src/content/cookies/main.md
+++ b/src/content/cookies/main.md
@@ -3,8 +3,6 @@ title: Cookies
 headerColour: dark
 ---
 
-# Cookies on this site
-
 Cookies are small files which are transferred to your device and then stored on your browser when you visit a website.
 
 We use cookies to analyse how you use our website, for example, which pages you visit. This helps us to improve our website, but we will only use cookies if you say we can.

--- a/src/content/cookies/main.md
+++ b/src/content/cookies/main.md
@@ -1,0 +1,12 @@
+---
+title: Cookies
+headerColour: dark
+---
+
+# Cookies on this site
+
+Cookies are small files which are transferred to your device and then stored on your browser when you visit a website.
+
+We use cookies to analyse how you use our website, for example, which pages you visit. This helps us to improve our website, but we will only use cookies if you say we can.
+
+You can read about how we use cookies in more detail in [our Privacy Notice](/privacy-notice/#cookies).

--- a/src/content/cookies/settings.md
+++ b/src/content/cookies/settings.md
@@ -1,3 +1,1 @@
-## Choose your cookie settings
-
 Please let us know whether or not we can use cookies. You can change this at any time from this page.

--- a/src/content/cookies/settings.md
+++ b/src/content/cookies/settings.md
@@ -1,0 +1,3 @@
+## Choose your cookie settings
+
+Please let us know whether or not we can use cookies. You can change this at any time from this page.

--- a/src/content/privacy-notice.md
+++ b/src/content/privacy-notice.md
@@ -137,8 +137,21 @@ You can contact the Information Commissioners Office on 0303 123 1113 or via ema
 
 ## <a name="cookies"></a> Use of Cookies
 
-A cookie consists of information sent by a web server to a web browser, and stored by the browser. The information is then sent back to the server each time the browser requests a page from the server. This enables the web server to identify and track the web browser.
+A cookie is a small text file sent by a web server to a web browser, and stored by the browser. The file is then sent back to the server each time the browser requests a page from the server. This enables the web server to identify and track the web browser.
 
-We use Google Analytics to analyse the use of this website. Google Analytics generates statistical and other information about website use by means of cookies, which are stored on users’ computers. The information generated relating to our website is used to create reports about the use of the website. Google will store this information. Google’s privacy policy is available at: <http://www.google.com/privacypolicy.html>.
+We use cookies to analyse how you use our website, for example, which pages you visit, how long you spend on each page and which links you click on. This helps us to understand how people are using our website so that we can make it better.
 
-Most browsers allow you to reject all cookies, whilst some browsers allow you to reject just third party cookies. For example, in Internet Explorer you can refuse all cookies by clicking “Tools”, “Internet Options”, “Privacy”, and selecting “Block all cookies” using the sliding selector. Blocking all cookies will, however, have a negative impact upon the usability of many websites.
+We use Google Analytics for analysing how people use our website. Google Analytics generates statistical and other information about how our website is being used, and then uses this to create reports. Google will store this information. Google’s privacy policy is available at: <http://www.google.com/privacypolicy.html>.
+
+Most browsers allow you to reject all cookies, whilst some browsers allow you to reject just third party cookies. Blocking all cookies will, however, have a negative impact upon the usability of many websites. You can find out how to do this for your browser using the following links:
+
+-   [Chrome](https://support.google.com/chrome/answer/95647)
+-   [Edge](https://support.microsoft.com/en-gb/help/4027947/microsoft-edge-delete-cookies)
+-   [Firefox](https://support.mozilla.org/en-US/kb/cookies-information-websites-store-on-your-computer#w_cookie-settings)
+-   [Safari (iOS)](https://support.apple.com/en-gb/HT201265)
+-   [Safari (macOS)](https://support.apple.com/en-gb/guide/safari/sfri11471/mac)
+-   [Opera](https://help.opera.com/en/latest/web-preferences/#cookies)
+-   [Samsung Internet](https://www.samsung.com/uk/support/mobile-devices/what-are-cookies-and-how-do-i-enable-or-disable-them-on-my-samsung-galaxy-device/)
+-   [Internet Explorer](https://support.microsoft.com/en-gb/help/17442/windows-internet-explorer-delete-manage-cookies)
+
+You can change your cookie settings for this website at any time at: <https://christchurchmayfair.org/cookies>.

--- a/src/content/privacy-notice.md
+++ b/src/content/privacy-notice.md
@@ -137,7 +137,7 @@ You can contact the Information Commissioners Office on 0303 123 1113 or via ema
 
 ## <a name="cookies"></a> Use of Cookies
 
-A cookie is a small text file sent by a web server to a web browser, and stored by the browser. The file is then sent back to the server each time the browser requests a page from the server. This enables the web server to identify and track the web browser.
+A cookie is a small piece of information sent by a web server to a web browser, and stored by the browser. The information is then sent back to the server each time the browser requests a page from the server. This enables the web server to identify and track the web browser.
 
 We use cookies to analyse how you use our website, for example, which pages you visit, how long you spend on each page and which links you click on. This helps us to understand how people are using our website so that we can make it better.
 

--- a/src/content/privacy-notice.md
+++ b/src/content/privacy-notice.md
@@ -154,4 +154,4 @@ Most browsers allow you to reject all cookies, whilst some browsers allow you to
 -   [Samsung Internet](https://www.samsung.com/uk/support/mobile-devices/what-are-cookies-and-how-do-i-enable-or-disable-them-on-my-samsung-galaxy-device/)
 -   [Internet Explorer](https://support.microsoft.com/en-gb/help/17442/windows-internet-explorer-delete-manage-cookies)
 
-You can change your cookie settings for this website at any time at: <https://christchurchmayfair.org/cookies>.
+You can change your cookie settings for this website at any time [here](/cookies).

--- a/src/pages/cookies.module.scss
+++ b/src/pages/cookies.module.scss
@@ -1,0 +1,26 @@
+.settingsContainer {
+    grid-area: content;
+
+    display: grid;
+    grid-row-gap: var(--general-padding);
+    grid-column-gap: var(--general-padding);
+    grid-template-areas:
+        "intro intro intro intro intro intro intro intro"
+        "switch switchLabel switchLabel switchLabel switchLabel switchLabel switchLabel switchLabel";
+
+    @media screen and (max-width: 650px) {
+        grid-column-gap: var(--general-padding) / 2;
+    }
+}
+
+.settingsIntroText {
+    grid-area: intro;
+}
+
+.switch {
+    grid-area: switch;
+}
+
+.switchLabel {
+    grid-area: switchLabel;
+}

--- a/src/pages/cookies.module.scss
+++ b/src/pages/cookies.module.scss
@@ -14,6 +14,7 @@
 }
 
 .settingsIntroText {
+    padding-top: var(--general-padding);
     grid-area: intro;
 }
 

--- a/src/pages/cookies.tsx
+++ b/src/pages/cookies.tsx
@@ -1,0 +1,91 @@
+import { graphql, useStaticQuery } from "gatsby"
+import React from "react"
+
+import { HeaderColour } from "../components/header"
+import HeaderUnderlay from "../components/header-underlay"
+import useConsentCookie from "../components/hooks/useConsentCookie"
+import Layout from "../components/layout"
+import Section from "../components/section"
+import SectionText from "../components/section-text"
+import Switch from "../components/switch"
+
+import styles from "./cookies.module.scss"
+
+const CookiesPageQuery = graphql`
+    query CookiesPage {
+        mainContent: markdownRemark(
+            fileAbsolutePath: { regex: "^/cookies/main.md$/" }
+        ) {
+            frontmatter {
+                title
+                headerColour
+            }
+            html
+        }
+        settingsContent: markdownRemark(
+            fileAbsolutePath: { regex: "^/cookies/settings.md$/" }
+        ) {
+            frontmatter {
+                title
+            }
+            html
+        }
+    }
+`
+
+const Cookies: React.FC<{}> = () => {
+    const data = useStaticQuery<GatsbyTypes.CookiesPageQuery>(CookiesPageQuery)
+    const [consentCookie, setConsentCookie] = useConsentCookie()
+
+    return (
+        <Layout
+            title={data.mainContent!.frontmatter!.title}
+            headerColour={
+                data.mainContent!.frontmatter!.headerColour as HeaderColour
+            }
+        >
+            <HeaderUnderlay />
+            <Section intro dark wider>
+                <SectionText intro dark>
+                    <div
+                        dangerouslySetInnerHTML={{
+                            __html: data.mainContent!.html!,
+                        }}
+                    />
+                </SectionText>
+            </Section>
+            <Section>
+                <div className={styles.settingsContainer}>
+                    <div
+                        className={styles.settingsIntroText}
+                        dangerouslySetInnerHTML={{
+                            __html: data.settingsContent!.html!,
+                        }}
+                    />
+                    <div className={styles.switch}>
+                        <Switch
+                            checked={consentCookie === "accepted"}
+                            disabled={consentCookie === undefined}
+                            onChange={mayUseCookies =>
+                                setConsentCookie(
+                                    mayUseCookies ? "accepted" : "declined"
+                                )
+                            }
+                            checkedText="on"
+                            uncheckedText="off"
+                        />
+                    </div>
+                    <div className={styles.switchLabel}>
+                        This website{" "}
+                        <strong>
+                            {consentCookie === "accepted" ? "may" : "may not"}
+                        </strong>{" "}
+                        use cookies.
+                    </div>
+                </div>
+            </Section>
+        </Layout>
+    )
+}
+
+export default Cookies

--- a/src/pages/cookies.tsx
+++ b/src/pages/cookies.tsx
@@ -71,8 +71,8 @@ const Cookies: React.FC<{}> = () => {
                                     mayUseCookies ? "accepted" : "declined"
                                 )
                             }
-                            checkedText="on"
-                            uncheckedText="off"
+                            checkedText="On"
+                            uncheckedText="Off"
                         />
                     </div>
                     <div className={styles.switchLabel}>


### PR DESCRIPTION
- Add a page at /cookies which users can use to change their cookie settings. A link to it has been added to the footer.
- Re-write cookies section in the privacy policy.
- Extract consent cookie logic into `useConsentCookie()` hook.

![image](https://user-images.githubusercontent.com/8490192/84581985-0e26f300-adde-11ea-81fa-22a9aa51b6ee.png)
