### PR TITLE
Allow neat override of OG data

### DIFF
--- a/src/components/head.tsx
+++ b/src/components/head.tsx
@@ -3,13 +3,18 @@ import { Helmet } from "react-helmet"
 import { useStaticQuery, graphql } from "gatsby"
 
 import HandInTheAir from "../content/assets/images/desktop/hand_in_the_air.jpg"
+import {
+    OpenGraphMetaData,
+    generateOpenGraphMetaTags,
+    MetaTag,
+} from "./open-graph"
 
 interface HeadProps {
     title: string | undefined
     description: string | undefined
-    meta?: Array<{ name: string; content: string }>
+    openGraphData?: OpenGraphMetaData
 }
-const Head: React.FC<HeadProps> = ({ title, description, meta = [] }) => {
+const Head: React.FC<HeadProps> = ({ title, description, openGraphData }) => {
     const { site } = useStaticQuery<GatsbyTypes.HeadQuery>(
         graphql`
             query Head {
@@ -34,24 +39,31 @@ const Head: React.FC<HeadProps> = ({ title, description, meta = [] }) => {
     const metadata = site!.siteMetadata!
     const metaDescription = description ?? metadata.description!
 
-    const helmetMeta = [
-        ...meta,
+    const defaultOpenGraphData: OpenGraphMetaData = {
+        title: title ?? metadata.title ?? "Missing Title",
+        type: "website",
+        siteName: metadata.title!,
+        url: metadata.url!,
+        description: metaDescription,
+        images: [
+            {
+                imageUrl: `${metadata.url}${HandInTheAir}`,
+                imageAlternativeText: "Christ Church Mayfair",
+            },
+        ],
+        email: metadata.email,
+        phoneNumber: metadata.officePhoneNumber,
+    }
 
+    const openGraphMetaTags = generateOpenGraphMetaTags(
+        openGraphData ?? defaultOpenGraphData
+    )
+
+    let helmetMeta: MetaTag[] = [
         // Basic HTML tags, SEO
         { name: `description`, content: metaDescription },
         { name: `url`, content: metadata.url! },
         { name: `robots`, content: metadata.robots! },
-
-        // OpenGraph tags
-        { property: `og:title`, content: title },
-        { property: "og:site_name", content: metadata.title! },
-        { property: `og:description`, content: metaDescription },
-        { property: `og:type`, content: `website` },
-        { property: `og:url`, content: metadata.url! },
-        { property: `og:image`, content: HandInTheAir },
-        { property: `og:image:alt`, content: `Christ Church Mayfair` },
-        { property: `og:email`, content: metadata.email! },
-        { property: `og:phone_number`, content: metadata.officePhoneNumber! },
 
         // Theme colour
         { name: `theme-color`, content: `#ffffff` },
@@ -62,6 +74,8 @@ const Head: React.FC<HeadProps> = ({ title, description, meta = [] }) => {
             content: `black-translucent`,
         },
     ]
+
+    helmetMeta = helmetMeta.concat(openGraphMetaTags)
 
     const pageTitle =
         title != null ? `${title} - ${metadata.title!}` : metadata.title!

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -13,12 +13,13 @@ import Footer from "./footer"
 import CookieNotice from "./cookie-notice"
 import "../assets/css/global.scss"
 import "../assets/css/style.css"
+import { OpenGraphMetaData } from "./open-graph"
 
 interface Props {
     children: React.ReactNode
     title: string | undefined
     description?: string | undefined
-    meta?: Array<{ name: string; content: string }>
+    openGraphData?: OpenGraphMetaData
     headerColour?: HeaderColour
 }
 const Layout: React.FC<Props> = ({
@@ -26,11 +27,15 @@ const Layout: React.FC<Props> = ({
     children,
     title,
     description,
-    meta,
+    openGraphData,
 }) => {
     return (
         <>
-            <Head title={title} description={description} meta={meta} />
+            <Head
+                title={title}
+                description={description}
+                openGraphData={openGraphData}
+            />
             <Header headerColour={headerColour} />
             <main>{children}</main>
             <Footer />

--- a/src/components/open-graph.test.ts
+++ b/src/components/open-graph.test.ts
@@ -1,0 +1,107 @@
+import { OpenGraphMetaData, generateOpenGraphMetaTags } from "./open-graph"
+
+test("returns basic open graph meta tags", () => {
+    const inputOpenGraphData: OpenGraphMetaData = {
+        title: "title",
+        type: "website",
+        url: "url",
+        description: "description",
+        images: [],
+    }
+
+    const result = generateOpenGraphMetaTags(inputOpenGraphData)
+
+    expect(result).toEqual(
+        expect.arrayContaining([{ property: "og:title", content: "title" }])
+    )
+    expect(result).toEqual(
+        expect.arrayContaining([{ property: "og:type", content: "website" }])
+    )
+    expect(result).toEqual(
+        expect.arrayContaining([{ property: "og:url", content: "url" }])
+    )
+    expect(result).toEqual(
+        expect.arrayContaining([
+            { property: "og:description", content: "description" },
+        ])
+    )
+
+    expect(result).not.toEqual(
+        expect.arrayContaining([
+            expect.objectContaining({
+                property: "og:phone_number",
+            }),
+        ])
+    )
+})
+
+test("returns optional open graph meta tags", () => {
+    const inputOpenGraphData: OpenGraphMetaData = {
+        title: "title",
+        type: "website",
+        url: "url",
+        description: "description",
+        images: [],
+        phoneNumber: "phone number",
+    }
+
+    const result = generateOpenGraphMetaTags(inputOpenGraphData)
+
+    expect(result).toEqual(
+        expect.arrayContaining([{ property: "og:title", content: "title" }])
+    )
+    expect(result).toEqual(
+        expect.arrayContaining([{ property: "og:type", content: "website" }])
+    )
+    expect(result).toEqual(
+        expect.arrayContaining([{ property: "og:url", content: "url" }])
+    )
+    expect(result).toEqual(
+        expect.arrayContaining([
+            { property: "og:description", content: "description" },
+        ])
+    )
+
+    expect(result).toEqual(
+        expect.arrayContaining([
+            { property: "og:phone_number", content: "phone number" },
+        ])
+    )
+})
+
+test("returns basic open graph meta tags with an image", () => {
+    const inputOpenGraphData: OpenGraphMetaData = {
+        title: "title",
+        type: "website",
+        url: "url",
+        description: "description",
+        images: [{ imageUrl: "imageUrl", imageWidth: 20, imageHeight: 30 }],
+    }
+
+    const result = generateOpenGraphMetaTags(inputOpenGraphData)
+
+    expect(result).toEqual(
+        expect.arrayContaining([{ property: "og:title", content: "title" }])
+    )
+    expect(result).toEqual(
+        expect.arrayContaining([{ property: "og:type", content: "website" }])
+    )
+    expect(result).toEqual(
+        expect.arrayContaining([{ property: "og:url", content: "url" }])
+    )
+    expect(result).toEqual(
+        expect.arrayContaining([
+            { property: "og:description", content: "description" },
+        ])
+    )
+    expect(result).toEqual(
+        expect.arrayContaining([{ property: "og:image", content: "imageUrl" }])
+    )
+
+    expect(result).toEqual(
+        expect.arrayContaining([{ property: "og:image:width", content: "20" }])
+    )
+    expect(result).toEqual(
+        expect.arrayContaining([{ property: "og:image:height", content: "30" }])
+    )
+})

--- a/src/components/open-graph.ts
+++ b/src/components/open-graph.ts
@@ -1,0 +1,57 @@
+export type OpenGraphImage = {
+    imageUrl: string
+    imageSecureUrl?: string
+    imageType?: string
+    imageWidth?: number
+    imageHeight?: number
+    imageAlternativeText?: string
+}
+
+export type OpenGraphMetaData = {
+    title: string
+    type: string
+    url: string
+    description: string
+    images: OpenGraphImage[]
+    email?: string
+    phoneNumber?: string
+    siteName?: string
+}
+
+export type MetaTag = JSX.IntrinsicElements["meta"]
+
+function generateOpenGraphImageMetaTags(imageData: OpenGraphImage): MetaTag[] {
+    return [
+        { property: "og:image", content: imageData.imageUrl },
+        {
+            property: "og:image:width",
+            content: imageData.imageWidth?.toString(),
+        },
+        {
+            property: "og:image:height",
+            content: imageData.imageHeight?.toString(),
+        },
+    ]
+}
+
+export function generateOpenGraphMetaTags(data: OpenGraphMetaData): MetaTag[] {
+    let basicMetaData: MetaTag[] = [
+        { property: "og:title", content: data.title },
+        { property: "og:type", content: data.type },
+        { property: "og:url", content: data.url },
+        { property: "og:description", content: data.description },
+        { property: "og:site_name", content: data.siteName },
+        { property: "og:phone_number", content: data.phoneNumber },
+        { property: "og:email", content: data.email },
+    ]
+
+    const imageMetaTags = data.images.flatMap(imageData =>
+        generateOpenGraphImageMetaTags(imageData)
+    )
+
+    basicMetaData = basicMetaData.concat(imageMetaTags)
+
+    return basicMetaData.filter(
+        tag => tag.content != null || tag.content === ""
+    )
+}


### PR DESCRIPTION
Added types for OG data. Set a default in head. Allow override if supplied.

Motivation is to make the overriding of this easy for London Living page.