### PR TITLE
Allow color scheme override for sections

### DIFF
--- a/src/components/basic-text-page.tsx
+++ b/src/components/basic-text-page.tsx
@@ -9,8 +9,8 @@ type BasicTextProps = {
 
 const BasicText: React.FC<BasicTextProps> = props => (
     <>
-        <HeaderUnderlay />
-        <Section>
+        <HeaderUnderlay colorScheme="light" />
+        <Section colorScheme="light">
             <article
                 dangerouslySetInnerHTML={{
                     __html: props.html ?? "Missing content",

--- a/src/components/double-image-section.tsx
+++ b/src/components/double-image-section.tsx
@@ -27,7 +27,7 @@ const DoubleImageSection: FC<DoubleImageSectionProps> = ({
                 [styles["doubleImageSection--right"]]:
                     imagesPosition === "right",
             })}
-            dark={dark}
+            colorScheme={dark ? "dark" : "light"}
         >
             <div className={styles.topImage}>{topImage}</div>
             <div className={styles.bottomImage}>{bottomImage}</div>

--- a/src/components/find-out-more.tsx
+++ b/src/components/find-out-more.tsx
@@ -12,6 +12,7 @@ const FindOutMore: FC<FindOutMoreProps> = ({
     ...elementProps
 }) => (
     <Section
+        colorScheme="light"
         className={classnames(className, styles.findOutMore)}
         {...elementProps}
     >

--- a/src/components/find-us.tsx
+++ b/src/components/find-us.tsx
@@ -34,7 +34,7 @@ const FindUs = () => {
 
     return (
         <div className={styles.findUsContainer}>
-            <Section id="find-us" className={styles.findUs}>
+            <Section id="find-us" className={styles.findUs} colorScheme="dark">
                 <h1 className={styles.title}>Find Us</h1>
                 <div className={styles.location}>
                     <MapPin className={styles.pin} viewBox="0 0 100 100" />

--- a/src/components/form/form.tsx
+++ b/src/components/form/form.tsx
@@ -151,7 +151,7 @@ export const Form = <DataType,>({
     )
 
     return (
-        <Section>
+        <Section colorScheme="light">
             <article>
                 {formState === "badconfig" ? badlyConfiguredForm : null}
                 {formState === "submitted" ? submitted : form}

--- a/src/components/header-underlay.tsx
+++ b/src/components/header-underlay.tsx
@@ -1,14 +1,23 @@
 import React, { FC, HTMLProps } from "react"
 
-import Section from "./section"
+import Section, { colorScheme } from "./section"
 
 import styles from "./header-underlay.module.scss"
 import classNames from "classnames"
 
-interface HeaderUnderlayProps extends HTMLProps<HTMLDivElement> {}
+interface HeaderUnderlayProps extends HTMLProps<HTMLDivElement> {
+    colorScheme: colorScheme
+}
 
-const HeaderUnderlay: FC<HeaderUnderlayProps> = ({ children, className }) => (
-    <Section className={classNames(className, styles.headerUnderlay)}>
+const HeaderUnderlay: FC<HeaderUnderlayProps> = ({
+    children,
+    className,
+    colorScheme,
+}) => (
+    <Section
+        className={classNames(className, styles.headerUnderlay)}
+        colorScheme={colorScheme}
+    >
         {children}
     </Section>
 )

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -17,7 +17,7 @@ const Hero: React.FC<HeroProps> = ({
     children,
 }) => (
     <div className={styles.heroContainer}>
-        <Section id={sectionId} className={styles.hero}>
+        <Section id={sectionId} colorScheme="custom" className={styles.hero}>
             <div className={styles.carouselOverlay}>
                 <h1 className={styles.overlayCaption}>{overlayCaption}</h1>
             </div>

--- a/src/components/important-notice.tsx
+++ b/src/components/important-notice.tsx
@@ -24,7 +24,11 @@ const ImportantNotice: FC<ImportantNoticeProps> = ({
     features = [],
 }) => (
     <div className={styles.importantNoticeContainer}>
-        <Section className={styles.importantNotice} fullBleed>
+        <Section
+            className={styles.importantNotice}
+            fullBleed
+            colorScheme="light"
+        >
             <div className={styles.content}>
                 <h1 className={styles.title}>{noticeTitle}</h1>
                 <SectionText fullBleed className={styles.text}>

--- a/src/components/section.module.scss
+++ b/src/components/section.module.scss
@@ -5,7 +5,6 @@
 
     padding-top: var(--general-padding);
     padding-bottom: var(--general-padding);
-    background-color: var(--light-colour);
     overflow: hidden;
 
     @media only screen and (max-width: 968px) {
@@ -76,6 +75,10 @@
         @media only screen and (max-width: 968px) {
             grid-template-areas: ". content content content content .";
         }
+    }
+
+    &--light {
+        background-color: var(--light-colour);
     }
 
     &--dark {

--- a/src/components/section.tsx
+++ b/src/components/section.tsx
@@ -11,10 +11,12 @@ type SectionImageBackgroundPosition =
     | "top-centre"
     | "bottom-centre"
 
+export type colorScheme = "dark" | "light" | "custom"
+
 interface SectionProps extends HTMLProps<HTMLDivElement> {
     intro?: boolean
     wider?: boolean
-    dark?: boolean
+    colorScheme: colorScheme
     mobileImageTextSwap?: boolean
     infoPanel?: boolean
     infoPanelImage?: ReactNode
@@ -27,7 +29,7 @@ interface SectionProps extends HTMLProps<HTMLDivElement> {
 const Section: FC<SectionProps> = ({
     intro = false,
     wider = false,
-    dark = false,
+    colorScheme: colorTheme,
     mobileImageTextSwap = false,
     infoPanel = false,
     infoPanelImage,
@@ -43,7 +45,8 @@ const Section: FC<SectionProps> = ({
         className={classnames(className, styles.section, {
             [styles["section--intro"]]: intro,
             [styles["section--wider-intro"]]: intro && wider,
-            [styles["section--dark"]]: dark,
+            [styles["section--dark"]]: colorTheme === "dark",
+            [styles["section--light"]]: colorTheme === "light",
             [styles["section--info-panel"]]: infoPanel,
             [styles["section--image-left"]]: imagePosition === "left",
             [styles["section--image-right"]]: imagePosition === "right",

--- a/src/components/services.tsx
+++ b/src/components/services.tsx
@@ -39,7 +39,7 @@ const Services = () => {
         }
     `)
     return (
-        <Section id="services" className={styles.services}>
+        <Section id="services" className={styles.services} colorScheme="dark">
             <h1 className={styles.heading}>Our Sunday Services</h1>
             {[data.am, data.pm].map(service => {
                 if (service == null) {

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -6,8 +6,8 @@ import Section from "../components/section"
 
 const NotFoundPage = () => (
     <Layout title="Page Not Found" description={undefined} headerColour="dark">
-        <HeaderUnderlay />
-        <Section>
+        <HeaderUnderlay colorScheme="light" />
+        <Section colorScheme="light">
             <article>
                 <h1>Error: Page not found</h1>
                 <p>

--- a/src/pages/aboutus.tsx
+++ b/src/pages/aboutus.tsx
@@ -53,7 +53,7 @@ const AboutUs: React.FC<{}> = () => {
     const data = useStaticQuery<GatsbyTypes.AboutUsPageQuery>(AboutUsPageQuery)
     return (
         <Layout title="About us" headerColour="dark">
-            <HeaderUnderlay />
+            <HeaderUnderlay colorScheme="light" />
             {data.aboutUsSections.nodes.map(section => (
                 <Fragment key={section.id}>
                     <Section
@@ -75,7 +75,11 @@ const AboutUs: React.FC<{}> = () => {
                                 }
                             />
                         }
-                        dark={section.frontmatter!.dark}
+                        colorScheme={
+                            section.frontmatter?.dark === true
+                                ? "dark"
+                                : "light"
+                        }
                         fullBleed={section.frontmatter!.fullBleed}
                         noImageOnMobile={section.frontmatter!.noImageOnMobile}
                         imagePosition={

--- a/src/pages/cookies.tsx
+++ b/src/pages/cookies.tsx
@@ -44,8 +44,8 @@ const Cookies: React.FC<{}> = () => {
                 data.mainContent!.frontmatter!.headerColour as HeaderColour
             }
         >
-            <HeaderUnderlay />
-            <Section intro dark wider>
+            <HeaderUnderlay colorScheme="light" />
+            <Section intro colorScheme={"dark"} wider>
                 <SectionText intro dark>
                     <div
                         dangerouslySetInnerHTML={{
@@ -54,7 +54,7 @@ const Cookies: React.FC<{}> = () => {
                     />
                 </SectionText>
             </Section>
-            <Section>
+            <Section colorScheme="light">
                 <div className={styles.settingsContainer}>
                     <div
                         className={styles.settingsIntroText}

--- a/src/pages/families.tsx
+++ b/src/pages/families.tsx
@@ -182,7 +182,7 @@ const Families: React.FC<{}> = () => {
                 }
                 imagePosition="right"
                 imageBackgroundPosition="right"
-                dark
+                colorScheme="dark"
                 mobileImageTextSwap
             >
                 <SectionText infoPanel dark>
@@ -221,6 +221,7 @@ const Families: React.FC<{}> = () => {
                         objectPosition="center top"
                     />
                 }
+                colorScheme="light"
                 fullBleed
                 noImageOnMobile
                 style={{

--- a/src/pages/givingform.tsx
+++ b/src/pages/givingform.tsx
@@ -190,8 +190,13 @@ const GivingFormPage: React.FC = () => {
 
     return (
         <Layout title="Giving Form" headerColour={"dark"}>
-            <HeaderUnderlay />
-            <Section intro wider dark className="intro wider dark">
+            <HeaderUnderlay colorScheme="light" />
+            <Section
+                intro
+                wider
+                colorScheme="dark"
+                className="intro wider dark"
+            >
                 <SectionText
                     intro
                     dark
@@ -203,7 +208,7 @@ const GivingFormPage: React.FC = () => {
             </Section>
 
             {googleFormSubmissionConfig?.warning !== undefined ? (
-                <Section id="notes">
+                <Section id="notes" colorScheme="light">
                     <article style={{ backgroundColor: "red", color: "white" }}>
                         {googleFormSubmissionConfig.warning}
                     </article>
@@ -374,7 +379,7 @@ const GivingFormPage: React.FC = () => {
                 />
             </Form>
             {givingFormState !== "submitted" ? (
-                <Section id="notes">
+                <Section id="notes" colorScheme="light">
                     <article
                         dangerouslySetInnerHTML={{
                             __html: data.notes?.html ?? "No Content!",

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -147,7 +147,7 @@ const IndexPage = () => {
                 </div>
             </Hero>
 
-            <Section intro>
+            <Section intro colorScheme="light">
                 <SectionText
                     intro
                     dangerouslySetInnerHTML={{
@@ -193,6 +193,7 @@ const IndexPage = () => {
                         objectPosition="center right"
                     />
                 }
+                colorScheme="light"
                 imagePosition="right"
                 imageBackgroundPosition="right"
             >

--- a/src/pages/littlelambs.tsx
+++ b/src/pages/littlelambs.tsx
@@ -75,7 +75,7 @@ const Families: React.FC<{}> = () => {
                 singleImageFluid={littleLambsImageFluid}
             />
 
-            <Section intro wider>
+            <Section intro wider colorScheme="light">
                 <SectionText
                     intro
                     dangerouslySetInnerHTML={{

--- a/src/pages/londonliving.tsx
+++ b/src/pages/londonliving.tsx
@@ -118,8 +118,11 @@ const LondonLivingPage: React.FC<{}> = () => {
             title={data.mainContent!.frontmatter!.title}
             description={undefined}
         >
-            <HeaderUnderlay className={styles.londonLiving} />
-            <Section className={styles.londonLiving}>
+            <HeaderUnderlay
+                className={styles.londonLiving}
+                colorScheme="custom"
+            />
+            <Section colorScheme="custom" className={styles.londonLiving}>
                 <div className={styles.content}>
                     <div className={styles.intro}>
                         <div className={styles.header}>

--- a/src/pages/music.tsx
+++ b/src/pages/music.tsx
@@ -170,7 +170,7 @@ const MusicPage: React.FC<{}> = () => {
                 overlayCaption={data.mainContent!.frontmatter!.overlayCaption}
                 singleImageFluid={fluid}
             />
-            <Section intro wider>
+            <Section intro wider colorScheme="light">
                 <SectionText
                     intro
                     dangerouslySetInnerHTML={{
@@ -198,7 +198,7 @@ const MusicPage: React.FC<{}> = () => {
                 }
                 imagePosition="right"
                 imageBackgroundPosition="right"
-                dark
+                colorScheme="dark"
             >
                 <SectionText infoPanel dark>
                     <h1>{data.extraContent!.frontmatter!.title}</h1>
@@ -210,7 +210,7 @@ const MusicPage: React.FC<{}> = () => {
                 </SectionText>
             </Section>
 
-            <Section>
+            <Section colorScheme="light">
                 <div className={styles.musicReleasesContainer}>
                     <h1>Releases</h1>
                     <div className={styles.musicReleases}>{releases}</div>
@@ -218,7 +218,7 @@ const MusicPage: React.FC<{}> = () => {
             </Section>
 
             <div className={styles.resourcesContainer}>
-                <Section className={styles.resources}>
+                <Section className={styles.resources} colorScheme="light">
                     <h1 className={styles.resourcesTitle}>
                         {data.resources!.frontmatter!.title}
                     </h1>

--- a/src/pages/sharingfaith.tsx
+++ b/src/pages/sharingfaith.tsx
@@ -105,9 +105,14 @@ const SharingFaithPage: React.FC<{}> = () => {
             title={"How Do I Share My Faith?"}
             description={undefined}
         >
-            <HeaderUnderlay />
+            <HeaderUnderlay colorScheme="light" />
 
-            <Section intro dark wider className="intro wider dark">
+            <Section
+                intro
+                colorScheme="dark"
+                wider
+                className="intro wider dark"
+            >
                 <SectionText
                     intro
                     dark
@@ -117,7 +122,7 @@ const SharingFaithPage: React.FC<{}> = () => {
                     }}
                 />
             </Section>
-            <Section intro className={"intro"}>
+            <Section intro className={"intro"} colorScheme="light">
                 <a
                     id="resources-button"
                     className="button index-top-section-btn"
@@ -134,14 +139,14 @@ const SharingFaithPage: React.FC<{}> = () => {
                 </a>
             </Section>
 
-            <Section>
+            <Section colorScheme="light">
                 <article
                     dangerouslySetInnerHTML={{
                         __html: data.videos?.html ?? "Missing content",
                     }}
                 />
             </Section>
-            <Section>
+            <Section colorScheme="light">
                 <YouTubeGallery
                     videoSections={
                         data.videos!.frontmatter!.sections as VideoSection[]
@@ -149,21 +154,21 @@ const SharingFaithPage: React.FC<{}> = () => {
                 />
             </Section>
 
-            <Section id={"resources"}>
+            <Section id={"resources"} colorScheme="light">
                 <div className={Styles.resourcesContainer}>
                     <h1>Resources</h1>
                     <div className={Styles.resources}>{resources}</div>
                 </div>
             </Section>
 
-            <Section id={"stories"}>
+            <Section id={"stories"} colorScheme="light">
                 <article
                     dangerouslySetInnerHTML={{
                         __html: data.stories?.html ?? "Missing content",
                     }}
                 />
             </Section>
-            <Section>
+            <Section colorScheme="light">
                 <YouTubeGallery
                     videoSections={
                         data.stories!.frontmatter!.sections! as VideoSection[]

--- a/src/pages/staff.tsx
+++ b/src/pages/staff.tsx
@@ -56,8 +56,8 @@ const Staff = () => {
 
     return (
         <Layout title={data.mainInfo?.frontmatter?.title} headerColour="dark">
-            <HeaderUnderlay />
-            <Section intro wider dark>
+            <HeaderUnderlay colorScheme="light" />
+            <Section intro wider colorScheme="dark">
                 <SectionText
                     intro
                     dangerouslySetInnerHTML={{
@@ -65,7 +65,7 @@ const Staff = () => {
                     }}
                 />
             </Section>
-            <Section>
+            <Section colorScheme="light">
                 <div className={styles.staffMembersContainer}>
                     {staffMembers.map(staffMember => (
                         <StaffMember key={staffMember.id} {...staffMember} />

--- a/src/pages/students.tsx
+++ b/src/pages/students.tsx
@@ -80,7 +80,7 @@ const Students: React.FC<{}> = () => {
                 overlayCaption={data.mainContent!.frontmatter!.overlayCaption}
                 singleImageFluid={fluid}
             />
-            <Section intro wider>
+            <Section intro wider colorScheme="light">
                 <SectionText
                     intro
                     dangerouslySetInnerHTML={{
@@ -108,7 +108,7 @@ const Students: React.FC<{}> = () => {
                 }
                 imagePosition="right"
                 imageBackgroundPosition="right"
-                dark
+                colorScheme="dark"
             >
                 <SectionText infoPanel dark>
                     <h1>{data.extraContent!.frontmatter!.title}</h1>

--- a/src/pages/talks.tsx
+++ b/src/pages/talks.tsx
@@ -51,7 +51,7 @@ const TalksPage = () => {
                 overlayCaption={meta.overlayCaption}
             />
             <div className={styles.talksContainer}>
-                <Section intro dark className={styles.talks}>
+                <Section intro colorScheme="dark" className={styles.talks}>
                     <SectionText
                         intro
                         dark
@@ -106,7 +106,7 @@ const TalksPage = () => {
                         />
                     </a>
                 </Section>
-                <Section className={styles.talksReactApp}>
+                <Section className={styles.talksReactApp} colorScheme="light">
                     <noscript>
                         You need to enable JavaScript to run this app.
                     </noscript>

--- a/src/pages/welcome.tsx
+++ b/src/pages/welcome.tsx
@@ -133,9 +133,14 @@ const WelcomePage: React.FC<{}> = () => {
 
     return (
         <Layout headerColour="dark" title={"Welcome"} description={undefined}>
-            <HeaderUnderlay />
+            <HeaderUnderlay colorScheme="light" />
 
-            <Section intro dark wider className="intro wider dark">
+            <Section
+                intro
+                colorScheme="dark"
+                wider
+                className="intro wider dark"
+            >
                 <SectionText
                     intro
                     dark
@@ -146,7 +151,7 @@ const WelcomePage: React.FC<{}> = () => {
                 />
             </Section>
 
-            <Section>
+            <Section colorScheme="light">
                 <div className={styles.bigVideoContent}>
                     <div
                         dangerouslySetInnerHTML={{
@@ -163,7 +168,7 @@ const WelcomePage: React.FC<{}> = () => {
             </Section>
 
             {googleFormSubmissionConfig?.warning != null ? (
-                <Section id="developmentwarning">
+                <Section id="developmentwarning" colorScheme="light">
                     <article style={{ backgroundColor: "red", color: "white" }}>
                         {googleFormSubmissionConfig.warning}
                     </article>
@@ -215,7 +220,7 @@ const WelcomePage: React.FC<{}> = () => {
                 />
             </Form>
 
-            <Section>
+            <Section colorScheme="light">
                 <article
                     dangerouslySetInnerHTML={{
                         __html: data.videos?.html ?? "Missing content",
@@ -223,7 +228,7 @@ const WelcomePage: React.FC<{}> = () => {
                 />
             </Section>
 
-            <Section>
+            <Section colorScheme="light">
                 <YouTubeGallery
                     videoSections={
                         data.videos!.frontmatter!.sections as VideoSection[]

--- a/src/templates/mailchimpsignup.tsx
+++ b/src/templates/mailchimpsignup.tsx
@@ -26,8 +26,8 @@ export const query = graphql`
 const MailchimpSignUpPage: React.FC<Props> = ({ data }) => {
     return (
         <Layout title={data.mainInfo!.frontmatter!.title} headerColour="dark">
-            <HeaderUnderlay />
-            <Section>
+            <HeaderUnderlay colorScheme="light" />
+            <Section colorScheme="light">
                 <article>
                     <div
                         dangerouslySetInnerHTML={{


### PR DESCRIPTION
Not all sections are dark or light. London Living is a prime example.

Provide the means to override this option by moving to an enum based system.

"custom" setting avoids setting and background colors. Without this the background colour wasn't possible to override and it was not showing up in development mode but only in production builds!

There must be a better way overall to do this but this is at least a bit better.