### PR TITLE
Adding covid 19 policy and risk assessment docs

### DIFF
--- a/src/components/basic-text-page.module.scss
+++ b/src/components/basic-text-page.module.scss
@@ -1,0 +1,34 @@
+
+.basicArticle {
+    font-family: "Klinic Slab";
+
+    h1 {
+        font-family: "Klinic Slab";
+        text-transform: none;
+        font-weight: 400;
+        line-height: 1.3em;
+    }
+
+    table {
+        border-collapse: collapse;
+        vertical-align: top;
+        width: 100%;
+
+        @media only screen and (max-width: 968px) {
+            font-size: 0.4em;
+        }
+    }
+
+    td, th {
+        border-style: solid;
+        border-color: var(--dark-colour);
+        border-width: 1px;
+        padding: 10px;
+        vertical-align: top;
+    }
+
+    thead {
+        background-color: var(--dark-colour);
+        color: var(--light-colour);
+    }
+}

--- a/src/components/basic-text-page.tsx
+++ b/src/components/basic-text-page.tsx
@@ -2,6 +2,7 @@ import React from "react"
 
 import HeaderUnderlay from "./header-underlay"
 import Section from "./section"
+import styles from "./basic-text-page.module.scss"
 
 type BasicTextProps = {
     html?: string
@@ -12,6 +13,7 @@ const BasicText: React.FC<BasicTextProps> = props => (
         <HeaderUnderlay colorScheme="light" />
         <Section colorScheme="light">
             <article
+                className={styles.basicArticle}
                 dangerouslySetInnerHTML={{
                     __html: props.html ?? "Missing content",
                 }}

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -8,7 +8,7 @@ import SocialMediaIcon from "./social-media-icon"
 
 const links: Array<{ path: string; title: string }> = [
     { path: "/littlelambs", title: "Little Lambs" },
-    { path: "/covid19", title: "Covid-19" },
+    { path: "/covid19", title: "Covid-19 Letter" },
     { path: "/our-beliefs", title: "Our Beliefs" },
     { path: "/talks", title: "Talks" },
     { path: "/privacy-notice", title: "Privacy Notice" },
@@ -20,6 +20,7 @@ const links: Array<{ path: string; title: string }> = [
     { path: "/aboutus", title: "About Us" },
     { path: "/accessibility", title: "Accessibility" },
     { path: "/staff", title: "Staff" },
+    { path: "/covid19-policy-and-risk-assessment", title: "Covid-19 Policy" },
 ]
 
 const Footer = () => {

--- a/src/content/covid19_risk_assessment.md
+++ b/src/content/covid19_risk_assessment.md
@@ -1,0 +1,514 @@
+---
+title: COVID-19 Policy
+path: /covid19-policy-and-risk-assessment
+showInFooter: true
+headerColour: dark
+template: basic
+---
+
+# COVID-19 Policy & Risk Assessment
+
+*Version 1:1*
+
+Date of implementation: 14 July 2020
+
+## 1. Purpose
+1.1 This policy is written to serve the church family, visitors and staff of Christ Church Mayfair for services and midweek bible study meetings in the building. 
+
+1.2 This policy will be reviewed:
+a) as our activities change e.g. when we re-start morning services;
+b) every month or more frequently if the Covid-10 situation changes and/or government/Church of England guidance varies in a way that would impact our meetings.
+
+## 2. Principles 
+We believe that the Bible teaches it is important for believers to meet together as a body wherever possible.
+
+We will aim to create an environment that makes it easy for people to adhere to government guidance and to reduce the risk of people catching or spreading Covid-19 as far as we are able.
+Staff and elders will lead by example.
+
+We will expect people to adhere to the principles and will encourage people to do so where possible.
+We are committed to following the latest government and Church of England guidance which can be found online at https://www.churchofengland.org/more/media-centre/coronavirus-covid-19-guidance-churches  and https://www.gov.uk/government/publications/covid-19-guidance-for-the-safe-use-of-placesof-worship-from-4-july/covid-19-guidance-for-the-safe-use-of-places-of-worship-from-4-july 
+
+## 3. CCM Church Context
+The context of this policy and risk assessment is within a plan to have a) an evening service from 19th July for those over the age of 11 and those with babes in arms only while livestreaming to those at home and not able to attend; b) a midweek meeting on Wednesday evenings for those over the age of 14 with a bible talk and discussion while livestreaming to those at home and not able to attend. With the experience gleaned from a few weeks of running evening services, this risk assessment will be modified to allow for additional services, including for the morning congregation.
+
+The numbers of COVID-19 cases in London have dropped considerably praise God and we are keen to implement current government recommendations to reduce the risk of spread as much as possible. We are also seeking to  be prepared for future eventualities.
+
+As the majority of the church family are under the age of 50, gathering together (in a safe manner) will not be a cause of great concern for many but we are concerned to protect as far as possible those who are more vulnerable and to welcome all ages safely to our building. CCM also has a duty of care to its staff and interns.
+
+For those who are concerned or who have to self-isolate/shield at home, as well as the number excluded by the restrictions the amount of physical space permits, live streaming will continue in order to be as inclusive as possible. 
+
+The church family were asked in a survey between 1st and 6th July for their opinion about church services restarting and in what format. We received 183 responses (from both individuals and households) and their thoughts and concerns have been taken into account. 
+
+## 4. Background
+COVID-19 (also known as SARS-CoV-19) is a new type of coronavirus which was originally identified in Wuhan, China.  Coronaviruses are a family of viruses which cause a range of illnesses; these include the common cold and severe acute respiratory syndrome (SARS).  The virus can be spread by direct droplet spread produced by coughing and sneezing but also by touching something contaminated with the virus (e.g. objects or surfaces) and then touching their face, nose or mouth.
+
+The symptoms of COVID-19 include fever, coughing and difficulty breathing, but some patients may have serious complications including pneumonia and renal failure. Many individuals do not display symptoms but may be infectious. Those who are older or with underlying medical problems are at higher risk of the serious manifestations.
+
+## 5. Risks and Mitigation
+
+<table>
+<thead>
+  <tr>
+    <th>Risks </th>
+    <th>Controls required </th>
+    <th>Additional information</th>
+    <th>Action by whom?</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td rowspan="4">Lingering infection in the building prior to opening. Possible infection from stagnant water (legionella)</td>
+    <td>Buildings have been aired before use.</td>
+    <td>All windows opened and doors front &amp; back left open for at least an hour</td>
+    <td>Interns</td>
+  </tr>
+  <tr>
+    <td>Disinfecting clean throught building</td>
+    <td></td>
+    <td>Regional cleaners</td>
+  </tr>
+  <tr>
+    <td>Water systems flushed through before use.<br>	</td>
+    <td>All taps run for 15 minutes and toilets flushed </td>
+    <td>Interns</td>
+  </tr>
+  <tr>
+    <td>Doors and windows to be opened during use wherever possible to improve ventilation. </td>
+    <td></td>
+    <td>Interns</td>
+  </tr>
+  <tr>
+    <td rowspan="3">Not knowing who attends an event  identify who was at the service for Track and Trace/to avoid exceeding capacity</td>
+    <td>Before return of wider church family e.g. while skeleton crew are going into church to broadcast, log book placed at entrance for people to record entrance &amp; exit</td>
+    <td>No pen left for multiple use</td>
+    <td>Intern</td>
+  </tr>
+  <tr>
+    <td>For Summer Specials and services, church family asked to sign up beforehand.<br>Spaces for newcomers built into total. Newcomers’ names and contact details requested on arrival. <br>For weddings, bride and groom asked to provide names of guests and contacts</td>
+    <td>Information held in compliance with GDPR and retained for 21 days to be shared with Track &amp; Trace if requested as per government guidance on <a href="https://www.gov.uk/government/publications/covid-19-guidance-for-the-safe-use-of-places-of-worship-during-the-pandemic-from-4-july/covid-19-guidance-for-the-safe-use-of-places-of-worship-during-the-pandemic-from-4-july">safe use of places of worship</a> (section 4). (Church family having already given consent for details held in ChurchSuite database, only necessary to give newcomers information about GDPR)   </td>
+    <td>Event organiser</td>
+  </tr>
+  <tr>
+    <td>If capacity is reached (see point 6 below), if no babies present, 2-3 of church family could go to balcony room and open windows. If more than this, ask those who live nearest to kindly forego their places.</td>
+    <td>Brief staff and stewards</td>
+    <td>Operations Manager </td>
+  </tr>
+  <tr>
+    <td rowspan="3">Queueing on entry causing social distancing challenges</td>
+    <td>Church family asked to arrive early and allow plenty of time to enter.</td>
+    <td></td>
+    <td>Event organiser</td>
+  </tr>
+  <tr>
+    <td>Clear signage and if necessary, tape on the pavement outside to encourage safe social distancing.</td>
+    <td></td>
+    <td>Operations Manager</td>
+  </tr>
+  <tr>
+    <td>Rapid seating through good stewarding.</td>
+    <td></td>
+    <td>Event organiser/interns</td>
+  </tr>
+  <tr>
+    <td rowspan="3">Incoming people infecting surfaces</td>
+    <td>Hand sanitiser stations placed at entrance for use as people enter</td>
+    <td></td>
+    <td>Interns</td>
+  </tr>
+  <tr>
+    <td>Put up notices to remind visitors about important safe practices e.g. keep social distance, practice hand washing etc.</td>
+    <td></td>
+    <td>Interns</td>
+  </tr>
+  <tr>
+    <td>Internal doors propped open before event (except door to men’s toilet) to reduce need for touching.</td>
+    <td></td>
+    <td>Intern</td>
+  </tr>
+  <tr>
+    <td rowspan="2"></td>
+    <td>If the church has been used in the last 72 hours ensure high-risk surfaces and touch points have been wiped with appropriate sanitiser spray or disposable wipes.  This includes between services or uses, even if multiple times during the day.</td>
+    <td></td>
+    <td>Intern</td>
+  </tr>
+  <tr>
+    <td>Cleaning of church after use (after each service if personnel change e.g. musicians/sound desk operators or at end of Sunday if same personnel all day) following checklist unless no-one will use the building for 72 hours.</td>
+    <td>See Appendix 3</td>
+    <td>Intern</td>
+  </tr>
+  <tr>
+    <td rowspan="10">Close contact on entry, while seated and on exit</td>
+    <td>Social distancing measures to be maintained where possible. Floor markings so indicate safe distances and posters displayed to reinforce</td>
+    <td></td>
+    <td>Operations Manager</td>
+  </tr>
+  <tr>
+    <td>One point of entry and different point of exit designated and clearly signed to manage flow of people. Emergency exits available at all times. <br>Bride will be allowed to enter via Brick Street entrance exceptionally and doors propped open for her entrance.</td>
+    <td>Enter through Down Street, exit via Brick Street. </td>
+    <td>Operations Manager</td>
+  </tr>
+  <tr>
+    <td>Flow of movement marked out for people entering and leaving the building to maintain physical distancing requirements.</td>
+    <td></td>
+    <td>Operations Manager</td>
+  </tr>
+  <tr>
+    <td>Front row of chairs placed at a safe distance (min. 2m) from the platform and not in line with lectern to minimise risk of being sprayed by service leader/reader etc.  Singers will be further back on the stage. </td>
+    <td></td>
+    <td>Intern</td>
+  </tr>
+  <tr>
+    <td>Seats spaced at minimum of 1m apart either individually or in households/social bubbles. No face to face seating.</td>
+    <td>See 6. Maximum capacity below<br></td>
+    <td>Intern</td>
+  </tr>
+  <tr>
+    <td>Discussion after talk at Summer Special to take place in Green Park if weather permits with max of 6 in one group socially distanced. <br>If in church, only 2 households at safe distance facing forwards. </td>
+    <td>Leader to make the call on the night</td>
+    <td>Leader</td>
+  </tr>
+  <tr>
+    <td>At the end of the event, people asked to stagger leaving times to avoid crowds at exit.</td>
+    <td>Verbal notice</td>
+    <td>Service leader</td>
+  </tr>
+  <tr>
+    <td>Guests asked not to gather in groups, except with members of their own household, inside or outside the building.</td>
+    <td>Verbal notices</td>
+    <td>Service leader</td>
+  </tr>
+  <tr>
+    <td>For weddings if the bride is to be ‘walked down the aisle’ she should only be accompanied by a member of her household, while bridesmaids should be careful to observe physical distancing unless also from the same household.</td>
+    <td></td>
+    <td>Minister in charge</td>
+  </tr>
+  <tr>
+    <td>Slides to be shown periodically through events reminding people to keep at a safe distance from one another and to wash hands/sanitise regularly. </td>
+    <td></td>
+    <td>Tech operator</td>
+  </tr>
+  <tr>
+    <td rowspan="8">Infection through sharing use of items </td>
+    <td>Access to kitchen and refreshment facilities/equipment will not be allowed. People will be asked to bring bottles of water with them.<br>If someone feels unwell and needs water, one church staff member only will enter the kitchen to obtain water, and will use a disposable cup. </td>
+    <td>Briefing beforehand</td>
+    <td>Operations Manager</td>
+  </tr>
+  <tr>
+    <td>All bibles and pens removed from use. </td>
+    <td></td>
+    <td>Intern</td>
+  </tr>
+  <tr>
+    <td>Access to kitchen and refreshment facilities/equipment will not be allowed. </td>
+    <td>Briefing beforehand</td>
+    <td>Event organiser </td>
+  </tr>
+  <tr>
+    <td>People encouraged to bring own bible/water/pen.</td>
+    <td></td>
+    <td>Event organiser</td>
+  </tr>
+  <tr>
+    <td>Children’s toys locked away and visiting families asked to bring own toys e.g. at a wedding.</td>
+    <td></td>
+    <td>Operations Manager</td>
+  </tr>
+  <tr>
+    <td>Weddings: Pen for signing registers to be wiped with sanitising gel before use. All signatories to sanitise hands before and after signing. </td>
+    <td></td>
+    <td>Minister in charge</td>
+  </tr>
+  <tr>
+    <td>Weddings: if required, orders of service to be placed on seats in advance using gloves. Guests asked to take them away at the end or put into recycling as they exit. </td>
+    <td>Briefing beforehand</td>
+    <td>Minister in charge</td>
+  </tr>
+  <tr>
+    <td>Weddings: Officiating minister blesses rings without touching them and blesses/prays for couple without contact.</td>
+    <td></td>
+    <td>Minister in charge</td>
+  </tr>
+  <tr>
+    <td rowspan="8">Infection through dispersion of aerosols  </td>
+    <td>All over the age of 10 requested to wear face covering while in the church. <br></td>
+    <td>The exceptions permitted by government for wearing face coverings e.g. for those with medical conditions etc to be followed <br>A few spare masks will be available at the entrance</td>
+    <td>Event organiser</td>
+  </tr>
+  <tr>
+    <td>Lectern placed 1m back from edge of platform. <br>Plexiglas screen to be placed in front of lectern so that those speaking at the lectern (service leader, preacher, reader etc) do not need to wear face covering while contributing to service</td>
+    <td>Screen on order</td>
+    <td>Interns</td>
+  </tr>
+  <tr>
+    <td>Safe protocols for use of microphones and washing of microphone windshields circulated for musicians and service leaders.</td>
+    <td>Distributed to interns, service leaders and musicians. <br>If different musicians to be used, they should also receive these protocols<br>See Appendix 2</td>
+    <td>Elena Stronach/Jo Hext</td>
+  </tr>
+  <tr>
+    <td>No loud music before/after service to reduce need for raised voices.</td>
+    <td></td>
+    <td>Sound desk operator</td>
+  </tr>
+  <tr>
+    <td>Musicians on stage to be located at 2m distance from one another. </td>
+    <td></td>
+    <td>Band leader</td>
+  </tr>
+  <tr>
+    <td>No congregational singing because of dispersal of aerosols.  Singing by one leader only behind Plexiglas screen. Plexiglass screen should be cleaned after use by the singer.</td>
+    <td>Live singing gives greater degree of church engagement and variety of songs than recorded so mitigation put in place to make this as safe as possible.</td>
+    <td>Operations Manager</td>
+  </tr>
+  <tr>
+    <td>Musicians asked to bring their own instrument e.g guitar and no wind instruments permitted. If keyboard is to be used, it should be wiped after each use. Similarly piano and stool. </td>
+    <td></td>
+    <td>Band leader/for a wedding: bride &amp; groom</td>
+  </tr>
+  <tr>
+    <td>Seats to be placed at the side of the stage at safe distance apart for band/service leader to sit in while not on stage. </td>
+    <td></td>
+    <td>Intern</td>
+  </tr>
+  <tr>
+    <td rowspan="6">Infection through visiting toilets</td>
+    <td>Check that handwashing &amp; toilet facilities have adequate soap provision before each use. <br>Hand dryers that require push button operation to be switched off and paper towels used</td>
+    <td>Government has confirmed use of hand dryers is safe in  <a href="https://www.gov.uk/government/publications/covid-19-guidance-for-the-safe-use-of-places-of-worship-during-the-pandemic-from-4-july/covid-19-guidance-for-the-safe-use-of-places-of-worship-during-the-pandemic-from-4-july">safe use of places of worship</a> (section 4). Those which operate on a sensor can still be used. </td>
+    <td>Intern</td>
+  </tr>
+  <tr>
+    <td>Alcohol gel stations placed in the entry way to the stairwell down to toilets with signs encouraging use on entry and exit to toilets.</td>
+    <td></td>
+    <td>Operations Manager</td>
+  </tr>
+  <tr>
+    <td>As access to toilets is via one narrow staircase and space within male &amp; female facilities limited, a maximum of one man and two women will be permitted downstairs at any one time. Someone should be designated to monitor this situation before and after the service begins. <br>Children under 11 e.g. at a wedding, to be accompanied to the toilet</td>
+    <td>Signage to be put up to say this</td>
+    <td>Intern</td>
+  </tr>
+  <tr>
+    <td>All asked to use disposable wipe/paper towel and spray to sanitise toilet seat, flush, taps and door handle as they exit. Signage to this effect in each toilet and materials provided. Signs in toilets to ask people to close lid before flushing.</td>
+    <td></td>
+    <td>Operations Manager</td>
+  </tr>
+  <tr>
+    <td>Public Health England signs displayed near each wash hand basin.</td>
+    <td></td>
+    <td>Operations Manager</td>
+  </tr>
+  <tr>
+    <td>Cleaning rota (with space for signature and tick) displayed on stairwell to toilets.</td>
+    <td></td>
+    <td>Operations Manager</td>
+  </tr>
+  <tr>
+    <td rowspan="2">Sharing Lord’s Supper</td>
+    <td>Receive bread only as permitted by Church of England.</td>
+    <td></td>
+    <td>Service leader</td>
+  </tr>
+  <tr>
+    <td>Mark aisle to keep safe distance between those receiving </td>
+    <td>Further consideration of Lord’s Supper needed</td>
+    <td>Interns</td>
+  </tr>
+  <tr>
+    <td>Upset baby during service</td>
+    <td>Parents can use balcony room which will then need to be wiped down after use</td>
+    <td>Brief any parents attending in advance</td>
+    <td>Event organiser</td>
+  </tr>
+  <tr>
+    <td>Safeguarding</td>
+    <td>All attending will be made aware that they could appear on camera and seats out of shot will be indicated for those who want them.</td>
+    <td>Warn in advance of attendance</td>
+    <td>Event organiser</td>
+  </tr>
+  <tr>
+    <td>Emergency evacuation </td>
+    <td>Emergency evacuation procedures e.g. in the event of a fire trump social distancing protocols </td>
+    <td>Brief staff and interns in advance</td>
+    <td>Operations Manager</td>
+  </tr>
+  <tr>
+    <td>Coronavirus case in church </td>
+    <td>Action Plan in place and communicated to leaders in event of Coronavirus case known to enter premises</td>
+    <td>See Appendix 4</td>
+    <td>Operations Manager</td>
+  </tr>
+</tbody>
+</table>
+
+
+## 6.  Capacity
+Asking for sign-ups will allow us to determine the maximum number who can attend  for any event
+Chairs will be laid out at safe social distance for those wearing face coverings, that is a minimum of 1m between households
+See Appendix 1
+
+## 7. Communications
+### 7.1
+The church family will be reminded when invitations to midweek meetings and Sunday services (and weddings) are issued that those  who are  vulnerable, shielding or self-isolating should remain at home and that those showing symptoms or self-isolating should not attend. 
+### 7.2
+The record of those signing up for each midweek bible study and Sunday service will be retained on ChurchSuite with additional names/contacts e.g newcomers retained by the church office for 21 days following GDPR although we will not compel people to give their names and contacts. For weddings the bride and groom will be asked to submit a list of the names of attendees in advance of the wedding which will be retained for 21 days (and which will allow the seat layout to be configured). If anyone submits their name for attendance, it will be assumed they attended, even if they pull out at the last minute. These lists will be made available to the government Track & Trace programme if necessary. 
+
+### 7.3
+If the church becomes aware of an individual who attended the service who has confirmed coronavirus, or who is likely to have coronavirus, advice will be sought from the local PHE Health Protection Team.
+
+## 8. Governance
+This has been drawn up by Sharon Walsh in consultation with the Elders and other members of CCM. 
+Date of review/approval
+
+<table>
+<thead>
+  <tr>
+    <th>Who</th>
+    <th>Date</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td>Staff and Interns</td>
+    <td>14/7/20</td>
+  </tr>
+  <tr>
+    <td>Elders</td>
+    <td>13/7/20</td>
+  </tr>
+  <tr>
+    <td>PCC</td>
+    <td>14/7/20</td>
+  </tr>
+  <tr>
+    <td>Trustees</td>
+    <td>14/7/20</td>
+  </tr>
+</tbody>
+</table>
+
+
+# Appendices
+
+## Appendix 1 - Maximum capacity
+
+Asking for sign-ups will allow us to determine the maximum who can attend  for any event
+one or two seats with 2m gap in all directions approx. 48 people. This number will increase if households/social bubbles of 4 or more are in the building (however there aren’t very many such families in the evening congregation) one or two seats with 1m gap in all directions (with face coverings or other mitigation) approx. 90 people. This number will increase if households/social bubbles of 4 or more are in the building 
+
+For weddings the maximum allowed by government guidelines is 30 including officiant but excluding verger/intern provided by church.
+
+## Appendix 2 - Safe Recording process
+
+Cleaning headset mics:
+One headset will be supplied per preacher, it should be labelled and only touched by the preacher & recorder
+Recorder wipes all down with alcohol wipes before and after the recording
+
+For each recording:
+1. Recorder puts batteries in beltpack, screws specific headset into beltpack
+2. Recorder checks signal is being received into the sound desk from the headset, and that the signal is going into the recording software
+3. Recorder wipes down all externals of headset & beltpack and leaves on a clean table
+4. Preacher collects headset & beltpack from table and fits it as normal for a Sunday Service
+5. Preacher does a test recording of roughly 2 minutes
+6. Recorder checks the test recording to ensure sound and video are coming in clearly
+7. Full recording of segments, do each segment in a separate recording
+8. Preacher removes headset/beltpack and leaves on the clean table
+9. Recorder removes batteries from beltpack and puts to charge, then cleans the beltpack and headset
+10. Recorder puts headset in sealed ziplock bag that has preacher’s name on a label
+11. Recorder wipes down table that had headset/beltpack on it
+
+Lectern mic:
+1. If the lectern mic needs to be used, the process is the same as the headsets in regards to wiping down the lectern stand, the microphone spine etc.
+2. The outside cover of the mic (windshield) is to be replaced after each use.
+3. Any used windshields are to be put in a ziplock bag and labelled clearly as needing to be washed
+
+## Appendix 3 - Cleaning Checklist
+The infection risk from coronavirus (COVID-19) following contamination of the environment decreases over time. It is not yet clear at what point there is no risk. However, studies of other viruses in the same family suggest that, in most circumstances, the risk is likely to be reduced significantly after 72 hours.
+
+<table>
+<thead>
+  <tr>
+    <th>After every use or daily</th>
+    <th>Action</th>
+    <th>Guidance </th>
+    <th>Completed <br>(tick)</th>
+    <th>Comments</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td>-</td>
+    <td>Put on disposable gloves before cleaning commences </td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Every use</td>
+    <td>Hard surfaces (including tables, lectern, seat frames) wiped with disinfectant wipe or disinfectant solution* &amp; disposable cloth/paper roll</td>
+    <td>Use yellow mop &amp; bucket for kitchen<br>Do not use bleach/other chemicals on historical surfaces e.g. wood of organ case <br></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Every use</td>
+    <td>‘High touch areas’ wiped  with disinfectant wipe or disinfectant solution &amp; disposable cloth/paper roll (including light switches, taps, door handles, stair rails, keyboards)</td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Every use</td>
+    <td>Toilets – including sinks, taps, flushes cleaned with disinfectant  or disinfectant solution &amp; disposable cloth/paper roll and floor cleaned with disinfectant solution. (Use the dedicated mop for this) </td>
+    <td>Use plastic bin bags where possible. <br>Use green mop &amp; bucket for toilets</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>After each event/<br>weekly</td>
+    <td>Hoover church floor (carpeted)</td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Daily</td>
+    <td>All bins emptied in church and toilets, bags tied and new bags put in</td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>-</td>
+    <td>Waste stored in area not accessible to children until it can be safely disposed of</td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>-</td>
+    <td>Hands washed with soap and water for 20 seconds, after removing PPE</td>
+    <td>Hand wash using warm water after cleaning and regularly throughout the day.</td>
+    <td></td>
+    <td></td>
+  </tr>
+</tbody>
+</table>
+
+*bleach solution 200ml to 5l water.
+
+*NB Available information suggests that unless they have been soiled soft furnishings do not need to be cleaned other than as part of your usual cleaning processes, which may include vacuuming with a soft brush attachment (CofE church cleaning guidance from June 2020)*
+
+### Cleaning/labelling supplies
+
+- There are wipes in the office/kitchen. Alternatively use alcohol-based sanitising gel on blue paper towel to wipe surfaces down. There is additional blue paper towel and individual paper towels in the basement.
+- Use labels from the office to put on the ziplock bags. Please bring a pen from home to use on the labels - do not use one of the church pens
+- Use disposable gloves from the kitchen. Let Sharon know if supplies are running low of this or other stock e.g. ziplock bags
+
+
+## Appendix 4 - Coronavirus Emergency Action Plan
+Should someone attending the church display symptoms of Coronavirus the following steps will be taken:
+1. The person will be asked to leave as soon as possible, return home and seek guidance from NHS111 as to self-isolation and testing.
+2. Anyone known to have been in close contact with the case advised to wash their hands as soon as possible
+3. Any surfaces likely to have been contaminated cleaned in line with cleaning guidance.
+4. Consider whether to bring the service to an early conclusion.
+5. Consult Health & Safety Executive website as to whether the event should be reported: https://www.hse.gov.uk/coronavirus/riddor/.
+6. Building to be closed for 72 hours before next use then cleaned
+7. If 72-hour closure is not possible then Public Health England guidance on cleaning in non-healthcare settings will be followed
+8. Follow-up with the individual to identify whether they have been diagnosed

--- a/src/content/covid19_risk_assessment.md
+++ b/src/content/covid19_risk_assessment.md
@@ -8,38 +8,45 @@ template: basic
 
 # COVID-19 Policy & Risk Assessment
 
-*Version 1:1*
+_Version 1:1_
 
 Date of implementation: 14 July 2020
 
 ## 1. Purpose
-1.1 This policy is written to serve the church family, visitors and staff of Christ Church Mayfair for services and midweek bible study meetings in the building. 
+
+1.1 This policy is written to serve the church family, visitors and staff of Christ Church Mayfair for services and midweek bible study meetings in the building.
 
 1.2 This policy will be reviewed:
 a) as our activities change e.g. when we re-start morning services;
 b) every month or more frequently if the Covid-10 situation changes and/or government/Church of England guidance varies in a way that would impact our meetings.
 
-## 2. Principles 
+## 2. Principles
+
 We believe that the Bible teaches it is important for believers to meet together as a body wherever possible.
 
 We will aim to create an environment that makes it easy for people to adhere to government guidance and to reduce the risk of people catching or spreading Covid-19 as far as we are able.
 Staff and elders will lead by example.
 
 We will expect people to adhere to the principles and will encourage people to do so where possible.
-We are committed to following the latest government and Church of England guidance which can be found online at https://www.churchofengland.org/more/media-centre/coronavirus-covid-19-guidance-churches  and https://www.gov.uk/government/publications/covid-19-guidance-for-the-safe-use-of-placesof-worship-from-4-july/covid-19-guidance-for-the-safe-use-of-places-of-worship-from-4-july 
+We are committed to following the latest government and Church of England guidance which can be found online:
+
+- [Church of England Guidance](https://www.churchofengland.org/more/media-centre/coronavirus-covid-19-guidance-churches)
+- [Government Guidance](https://www.gov.uk/government/publications/covid-19-guidance-for-the-safe-use-of-places-of-worship-from-4-july/covid-19-guidance-for-the-safe-use-of-places-of-worship-from-4-july)
 
 ## 3. CCM Church Context
+
 The context of this policy and risk assessment is within a plan to have a) an evening service from 19th July for those over the age of 11 and those with babes in arms only while livestreaming to those at home and not able to attend; b) a midweek meeting on Wednesday evenings for those over the age of 14 with a bible talk and discussion while livestreaming to those at home and not able to attend. With the experience gleaned from a few weeks of running evening services, this risk assessment will be modified to allow for additional services, including for the morning congregation.
 
-The numbers of COVID-19 cases in London have dropped considerably praise God and we are keen to implement current government recommendations to reduce the risk of spread as much as possible. We are also seeking to  be prepared for future eventualities.
+The numbers of COVID-19 cases in London have dropped considerably praise God and we are keen to implement current government recommendations to reduce the risk of spread as much as possible. We are also seeking to be prepared for future eventualities.
 
 As the majority of the church family are under the age of 50, gathering together (in a safe manner) will not be a cause of great concern for many but we are concerned to protect as far as possible those who are more vulnerable and to welcome all ages safely to our building. CCM also has a duty of care to its staff and interns.
 
-For those who are concerned or who have to self-isolate/shield at home, as well as the number excluded by the restrictions the amount of physical space permits, live streaming will continue in order to be as inclusive as possible. 
+For those who are concerned or who have to self-isolate/shield at home, as well as the number excluded by the restrictions the amount of physical space permits, live streaming will continue in order to be as inclusive as possible.
 
-The church family were asked in a survey between 1st and 6th July for their opinion about church services restarting and in what format. We received 183 responses (from both individuals and households) and their thoughts and concerns have been taken into account. 
+The church family were asked in a survey between 1st and 6th July for their opinion about church services restarting and in what format. We received 183 responses (from both individuals and households) and their thoughts and concerns have been taken into account.
 
 ## 4. Background
+
 COVID-19 (also known as SARS-CoV-19) is a new type of coronavirus which was originally identified in Wuhan, China.  Coronaviruses are a family of viruses which cause a range of illnesses; these include the common cold and severe acute respiratory syndrome (SARS).  The virus can be spread by direct droplet spread produced by coughing and sneezing but also by touching something contaminated with the virus (e.g. objects or surfaces) and then touching their face, nose or mouth.
 
 The symptoms of COVID-19 include fever, coughing and difficulty breathing, but some patients may have serious complications including pneumonia and renal failure. Many individuals do not display symptoms but may be infectious. Those who are older or with underlying medical problems are at higher risk of the serious manifestations.
@@ -338,23 +345,25 @@ The symptoms of COVID-19 include fever, coughing and difficulty breathing, but s
 </tbody>
 </table>
 
+## 6. Capacity
 
-## 6.  Capacity
-Asking for sign-ups will allow us to determine the maximum number who can attend  for any event
+Asking for sign-ups will allow us to determine the maximum number who can attend for any event
+
 Chairs will be laid out at safe social distance for those wearing face coverings, that is a minimum of 1m between households
+
 See Appendix 1
 
 ## 7. Communications
-### 7.1
-The church family will be reminded when invitations to midweek meetings and Sunday services (and weddings) are issued that those  who are  vulnerable, shielding or self-isolating should remain at home and that those showing symptoms or self-isolating should not attend. 
-### 7.2
-The record of those signing up for each midweek bible study and Sunday service will be retained on ChurchSuite with additional names/contacts e.g newcomers retained by the church office for 21 days following GDPR although we will not compel people to give their names and contacts. For weddings the bride and groom will be asked to submit a list of the names of attendees in advance of the wedding which will be retained for 21 days (and which will allow the seat layout to be configured). If anyone submits their name for attendance, it will be assumed they attended, even if they pull out at the last minute. These lists will be made available to the government Track & Trace programme if necessary. 
 
-### 7.3
-If the church becomes aware of an individual who attended the service who has confirmed coronavirus, or who is likely to have coronavirus, advice will be sought from the local PHE Health Protection Team.
+7.1 The church family will be reminded when invitations to midweek meetings and Sunday services (and weddings) are issued that those who are vulnerable, shielding or self-isolating should remain at home and that those showing symptoms or self-isolating should not attend.
+
+7.2 The record of those signing up for each midweek bible study and Sunday service will be retained on ChurchSuite with additional names/contacts e.g newcomers retained by the church office for 21 days following GDPR although we will not compel people to give their names and contacts. For weddings the bride and groom will be asked to submit a list of the names of attendees in advance of the wedding which will be retained for 21 days (and which will allow the seat layout to be configured). If anyone submits their name for attendance, it will be assumed they attended, even if they pull out at the last minute. These lists will be made available to the government Track & Trace programme if necessary.
+
+7.3 If the church becomes aware of an individual who attended the service who has confirmed coronavirus, or who is likely to have coronavirus, advice will be sought from the local PHE Health Protection Team.
 
 ## 8. Governance
-This has been drawn up by Sharon Walsh in consultation with the Elders and other members of CCM. 
+
+This has been drawn up by Sharon Walsh in consultation with the Elders and other members of CCM.
 Date of review/approval
 
 <table>
@@ -384,23 +393,25 @@ Date of review/approval
 </tbody>
 </table>
 
-
 # Appendices
 
-## Appendix 1 - Maximum capacity
+## Appendix 1 - Maximum Capacity
 
-Asking for sign-ups will allow us to determine the maximum who can attend  for any event
-one or two seats with 2m gap in all directions approx. 48 people. This number will increase if households/social bubbles of 4 or more are in the building (however there aren’t very many such families in the evening congregation) one or two seats with 1m gap in all directions (with face coverings or other mitigation) approx. 90 people. This number will increase if households/social bubbles of 4 or more are in the building 
+Asking for sign-ups will allow us to determine the maximum who can attend for any event:
 
-For weddings the maximum allowed by government guidelines is 30 including officiant but excluding verger/intern provided by church.
+-   one or two seats with 2m gap in all directions approx. 48 people. This number will increase if households/social bubbles of 4 or more are in the building (however there aren’t very many such families in the evening congregation)
+-   one or two seats with 1m gap in all directions (with face coverings or other mitigation) approx. 90 people. This number will increase if households/social bubbles of 4 or more are in the building
+-   For weddings the maximum allowed by government guidelines is 30 including officiant but excluding verger/intern provided by church.
 
-## Appendix 2 - Safe Recording process
+## Appendix 2 - Safe Recording Process
 
-Cleaning headset mics:
+### Cleaning headset mics
+
 One headset will be supplied per preacher, it should be labelled and only touched by the preacher & recorder
 Recorder wipes all down with alcohol wipes before and after the recording
 
-For each recording:
+### For each recording
+
 1. Recorder puts batteries in beltpack, screws specific headset into beltpack
 2. Recorder checks signal is being received into the sound desk from the headset, and that the signal is going into the recording software
 3. Recorder wipes down all externals of headset & beltpack and leaves on a clean table
@@ -413,12 +424,14 @@ For each recording:
 10. Recorder puts headset in sealed ziplock bag that has preacher’s name on a label
 11. Recorder wipes down table that had headset/beltpack on it
 
-Lectern mic:
+### Lectern mic
+
 1. If the lectern mic needs to be used, the process is the same as the headsets in regards to wiping down the lectern stand, the microphone spine etc.
 2. The outside cover of the mic (windshield) is to be replaced after each use.
 3. Any used windshields are to be put in a ziplock bag and labelled clearly as needing to be washed
 
 ## Appendix 3 - Cleaning Checklist
+
 The infection risk from coronavirus (COVID-19) following contamination of the environment decreases over time. It is not yet clear at what point there is no risk. However, studies of other viruses in the same family suggest that, in most circumstances, the risk is likely to be reduced significantly after 72 hours.
 
 <table>
@@ -491,19 +504,20 @@ The infection risk from coronavirus (COVID-19) following contamination of the en
 </tbody>
 </table>
 
-*bleach solution 200ml to 5l water.
+\*bleach solution 200ml to 5l water.
 
-*NB Available information suggests that unless they have been soiled soft furnishings do not need to be cleaned other than as part of your usual cleaning processes, which may include vacuuming with a soft brush attachment (CofE church cleaning guidance from June 2020)*
+_NB Available information suggests that unless they have been soiled soft furnishings do not need to be cleaned other than as part of your usual cleaning processes, which may include vacuuming with a soft brush attachment (CofE church cleaning guidance from June 2020)_
 
 ### Cleaning/labelling supplies
 
-- There are wipes in the office/kitchen. Alternatively use alcohol-based sanitising gel on blue paper towel to wipe surfaces down. There is additional blue paper towel and individual paper towels in the basement.
-- Use labels from the office to put on the ziplock bags. Please bring a pen from home to use on the labels - do not use one of the church pens
-- Use disposable gloves from the kitchen. Let Sharon know if supplies are running low of this or other stock e.g. ziplock bags
-
+-   There are wipes in the office/kitchen. Alternatively use alcohol-based sanitising gel on blue paper towel to wipe surfaces down. There is additional blue paper towel and individual paper towels in the basement.
+-   Use labels from the office to put on the ziplock bags. Please bring a pen from home to use on the labels - do not use one of the church pens
+-   Use disposable gloves from the kitchen. Let Sharon know if supplies are running low of this or other stock e.g. ziplock bags
 
 ## Appendix 4 - Coronavirus Emergency Action Plan
+
 Should someone attending the church display symptoms of Coronavirus the following steps will be taken:
+
 1. The person will be asked to leave as soon as possible, return home and seek guidance from NHS111 as to self-isolation and testing.
 2. Anyone known to have been in close contact with the case advised to wash their hands as soon as possible
 3. Any surfaces likely to have been contaminated cleaned in line with cleaning guidance.


### PR DESCRIPTION
This document is something that we must have avaiable for public viewing.

I have used html tables as MD tables were not able to do spanrows/spancolumns and alternatives where way too hard to work with.

In this case I used an online converter to generate a unstyled table from the source doc tables.

Added specific styling for basic text docs so that we can control things a bit more independently.